### PR TITLE
General code tidy-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ hs_err_pid*
 # ###
 
 target/
+work/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -1,41 +1,51 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <groupId>de.jamba.hudson.plugin.wsclean</groupId>
-  <artifactId>hudson-wsclean-plugin</artifactId>
-  <packaging>hpi</packaging>
-  <name>Distributed Workspace Clean plugin</name>
-  <version>1.0.6-SNAPSHOT</version>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Distributed+Workspace+Clean+plugin</url>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.424</version>
-  </parent>
+    <groupId>de.jamba.hudson.plugin.wsclean</groupId>
+    <artifactId>hudson-wsclean-plugin</artifactId>
+    <packaging>hpi</packaging>
+    <name>Distributed Workspace Clean plugin</name>
+    <version>${revision}${changelist}</version>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Distributed+Workspace+Clean+plugin</url>
 
-  <description>This plugin cleans all other workspace directories for the same BuildProject within as same slave group</description>
-  <organization>
-  	<name>Fox Mobile Distribution GmbH</name>
-  	<url>http://www.jamba.de</url>
-  </organization>
-  <developers>
-    <developer>
-      <id>tspengler</id>
-      <name>Thomas Spengler</name>
-    </developer>
-    <developer>
-      <id>aheritier</id>
-      <name>Arnaud Héritier</name>
-    </developer>
-  </developers>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>3.19</version>
+    </parent>
 
-  <scm>
-    <connection>scm:git:git@github.com:jenkinsci/wsclean-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/wsclean-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/wsclean-plugin</url>
-    <tag>HEAD</tag>
-  </scm>
+    <description>This plugin cleans all other workspace directories for the same BuildProject within as same slave group</description>
+    <organization>
+        <name>Fox Mobile Distribution GmbH</name>
+        <url>http://www.jamba.de</url>
+    </organization>
+    <developers>
+        <developer>
+            <id>tspengler</id>
+            <name>Thomas Spengler</name>
+        </developer>
+        <developer>
+            <id>aheritier</id>
+            <name>Arnaud Héritier</name>
+        </developer>
+    </developers>
+
+    <properties>
+        <revision>1.0.6</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.level>8</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+    </properties>
+
+    <scm>
+        <connection>scm:git:git@github.com:jenkinsci/wsclean-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/wsclean-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/wsclean-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <repositories>
         <repository>
@@ -50,6 +60,20 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
 
+    <dependencies>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
@@ -1,5 +1,13 @@
 package de.jamba.hudson.plugin.wsclean;
 
+import java.io.IOException;
+import java.util.Set;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -13,132 +21,127 @@ import hudson.remoting.RequestAbortedException;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 
-import java.io.IOException;
-import java.util.Set;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-
 public class PrePostClean extends BuildWrapper {
 
-	public boolean before;
-	private boolean behind;
+    public boolean before;
 
-	public boolean isBefore() {
-		return before;
-	}
+    @SuppressWarnings("unused")
+    @Deprecated
+    private transient Boolean behind; // not used, but can appear in old configurations
 
-	public void setBefore(boolean before) {
-		this.before = before;
-		this.behind = !before;
-	}
+    public PrePostClean() {
+    }
 
-	@DataBoundConstructor
-	public PrePostClean(boolean before) {
-		this.before = before;
-		this.behind = !before;
-	}
+    @DataBoundConstructor
+    public PrePostClean(boolean before) {
+        this();
+        setBefore(before);
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Environment setUp(AbstractBuild build, Launcher launcher,
-			BuildListener listener) throws IOException, InterruptedException {
+    public boolean isBefore() {
+        return before;
+    }
 
-		// TearDown
-		class TearDownImpl extends Environment {
+    @DataBoundSetter
+    public void setBefore(boolean before) {
+        this.before = before;
+    }
 
-			@Override
-			public boolean tearDown(AbstractBuild build, BuildListener listener)
-					throws IOException, InterruptedException {
-				if (behind) {
-					executeOnSlaves(build, listener);
-				}
-				return super.tearDown(build, listener);
-			}
-
-		}
-
-		if (before) {
-			executeOnSlaves(build, listener);
-		}
-		return new TearDownImpl();
-
-	}
-
-	@SuppressWarnings("rawtypes")
-	private void executeOnSlaves(AbstractBuild build, BuildListener listener) {
-		listener.getLogger().println("run PrePostClean");
-		// select actual running label
-		String runNode = build.getBuiltOnStr();
-
-
-		if (runNode.length() == 0) {
-			listener.getLogger().println("running on master");
-		} else {
-			listener.getLogger().println("running on " + runNode);
-		}
-
-		AbstractProject project = build.getProject();
-		Label assignedLabel = project.getAssignedLabel();
-		if (assignedLabel == null) {
- 			listener.getLogger().println("skipping roaming project.");
- 			return;
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener)
+            throws IOException, InterruptedException {
+        final boolean runAtStart = isBefore();
+        final boolean runAtEnd = !runAtStart;
+        // TearDown
+        class TearDownImpl extends Environment {
+            @Override
+            public boolean tearDown(AbstractBuild build, BuildListener listener)
+                    throws IOException, InterruptedException {
+                if (runAtEnd) {
+                    executeOnSlaves(build, listener);
+                }
+                return super.tearDown(build, listener);
+            }
         }
- 		Set<Node> nodesForLabel = assignedLabel.getNodes();
-		if (nodesForLabel != null) {
-			for (Node node : nodesForLabel) {
-				if (!runNode.equals(node.getNodeName())) {
-					String normalizedName = "".equals(node.getNodeName()) ? "master" : node.getNodeName();
-						listener.getLogger().println(
-								"cleaning on " + normalizedName);
-						deleteWorkspaceOn(project, listener, node, normalizedName);
-				}
 
-			}
-		}
-	}
+        if (runAtStart) {
+            executeOnSlaves(build, listener);
+        }
+        return new TearDownImpl();
+    }
 
-	@SuppressWarnings("rawtypes")
-	private void deleteWorkspaceOn(AbstractProject project, BuildListener listener, Node node, String nodeName) {
-		if (project instanceof TopLevelItem) {
-			FilePath fp = node.getWorkspaceFor((TopLevelItem) project);
-			if (fp != null) {
-				try {
-					fp.deleteContents();
-				} catch (IOException e) {
-					listener.getLogger().println(
-							"can't delete on node " + nodeName + "\n" + e.getMessage());
-					listener.getLogger().print(e);
-				} catch (InterruptedException e) {
-					listener.getLogger().println(
-							"can't delete on node " + nodeName + "\n" + e.getMessage());
-					listener.getLogger().print(e);
-				} catch (RequestAbortedException e){
-					listener.getLogger().println(
-							"can't delete on node " + nodeName + "\n" + e.getMessage());
-				}
-				
-			} else {
-				listener.getLogger().println(
-						"No workspace found on " + nodeName + ". Node is maybe offline.");
-			}
-		} else {
-			listener.getLogger().println("Project is no TopLevelItem!? Cannot determine other workspaces!");
-		}
-	}
+    private void executeOnSlaves(AbstractBuild<?, ?> build, BuildListener listener) throws InterruptedException {
+        listener.getLogger().println("Run PrePostClean");
+        // select actual running label
+        String runNode = build.getBuiltOnStr();
 
-	@Extension
-	public static final class DescriptorImpl extends BuildWrapperDescriptor {
-		public DescriptorImpl() {
-			super(PrePostClean.class);
-		}
+        listener.getLogger().println("Running on " + toNormalizedNodeName(runNode));
 
-		public String getDisplayName() {
-			return "Clean up all other workspaces of this job in the same slavegroup";
-		}
+        AbstractProject<?, ?> project = build.getProject();
+        Label assignedLabel = project.getAssignedLabel();
+        if (assignedLabel == null) {
+            listener.getLogger().println("Skipping roaming project.");
+            return;
+        }
+        Set<Node> nodesForLabel = assignedLabel.getNodes();
+        if (nodesForLabel != null) {
+            for (Node node : nodesForLabel) {
+                String nodeName = node.getNodeName();
+                if (!runNode.equals(nodeName)) {
+                    String normalizedName = toNormalizedNodeName(nodeName);
+                    listener.getLogger().println("Cleaning on " + normalizedName);
+                    deleteWorkspaceOn(project, listener, node, normalizedName);
+                }
+            }
+        }
+    }
 
-		public boolean isApplicable(AbstractProject<?, ?> item) {
-			return true;
-		}
+    private void deleteWorkspaceOn(AbstractProject<?, ?> project, BuildListener listener, Node node, String nodeName)
+            throws InterruptedException {
+        if (project instanceof TopLevelItem) {
+            FilePath fp = node.getWorkspaceFor((TopLevelItem) project);
+            if (fp != null) {
+                deleteWorkspaceOn(listener, nodeName, fp);
+            } else {
+                listener.getLogger().println("No workspace found on " + nodeName + ". Node is maybe offline.");
+            }
+        } else {
+            listener.getLogger().println("Project is no TopLevelItem!? Cannot determine other workspaces!");
+        }
+    }
 
-	}
+    /* This is only non-private for test purposes. */
+    @Restricted(NoExternalUse.class) // unit-test only
+    void deleteWorkspaceOn(BuildListener listener, String nodeName, FilePath fp) throws InterruptedException {
+        try {
+            fp.deleteContents();
+        } catch (IOException | RequestAbortedException e) {
+            listener.getLogger()
+                    .println("Can't delete " + fp.getRemote() + " on node " + nodeName + "\n" + e.getMessage());
+            listener.getLogger().print(e);
+        }
+    }
+
+    private static String toNormalizedNodeName(String nodeName) {
+        final String normalizedNodeName = (nodeName == null || "".equals(nodeName)) ? "master" : nodeName;
+        return normalizedNodeName;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildWrapperDescriptor {
+        public DescriptorImpl() {
+            super(PrePostClean.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.PrePostClean_displayName();
+        }
+
+        @Override
+        public boolean isApplicable(AbstractProject<?, ?> item) {
+            return true;
+        }
+    }
 }

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/Messages.properties
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/Messages.properties
@@ -1,0 +1,1 @@
+PrePostClean.displayName=Clean up all other workspaces of this job in the same slavegroup

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/config.jelly
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/config.jelly
@@ -1,8 +1,8 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	
-	<f:entry  >
-		
-      <f:checkbox name="hudson-wslean-plugin.before" checked="${instance.before}"/>
-      execute the clean before and not behind the build
-   </f:entry>
+    <f:advanced>
+        <f:entry title="${%Clean before build}" field="before">
+            <f:checkbox/>
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/global.jelly
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <!-- nothing to configure -->
+    <!-- nothing to configure -->
 </j:jelly>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help-before.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help-before.html
@@ -1,0 +1,5 @@
+<div>
+    If set, the cleanup is done at the start of the build.
+    <br>
+    If not set, the cleanup is done at the end of the build.
+</div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help.html
@@ -1,0 +1,14 @@
+<div>
+    Cleans up workspaces from this job's old builds on other slave nodes.
+    <p>
+    By default, a slave node will leave a build's workspace on the slave node's filesystem
+    indefinitely (until it gets overwritten by a new build).
+    When there's a (large) pool of persistent slave nodes available to run a (large) number of builds,
+    eventually every slave node ends up with a copy of every builds' workspace.
+    This is a waste of hardware resources as Jenkins will only look at the workspace on the most
+    recently used slave node.
+    <br>
+    This functionality triggers a clean up of the workspace on all slave nodes
+    that are not currently being used so that, on average, the pool of slaves will only
+    contain one workspace for each job.
+</div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,8 +1,4 @@
-<!--
-  This view is used to render the plugin list page.
-
-  Since we don't really have anything dynamic here, let's just use static HTML. 
--->
+<?jelly escape-by-default='true'?>
 <div>
-  This plugin offers the possibility to cleanup the job workspace on all other slaves
+    Allows cleanup of old job workspaces on slaves used by old builds.
 </div>

--- a/src/test/java/de/jamba/hudson/plugin/wsclean/PrePostCleanTest.java
+++ b/src/test/java/de/jamba/hudson/plugin/wsclean/PrePostCleanTest.java
@@ -1,0 +1,222 @@
+package de.jamba.hudson.plugin.wsclean;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.collect.ImmutableSet;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.TopLevelItem;
+import hudson.remoting.VirtualChannel;
+import hudson.tasks.BuildWrapper.Environment;
+import jenkins.model.Jenkins;
+
+@SuppressWarnings("rawtypes")
+public class PrePostCleanTest {
+    @Test
+    public void constructorGivenDefaultsThenReturnsDefaultInstance() throws Exception {
+        // Given
+        final boolean expectedBefore = false;
+
+        // When
+        final PrePostClean instance = new PrePostClean();
+        final boolean actualBefore = instance.isBefore();
+
+        // Then
+        assertThat(actualBefore, equalTo(expectedBefore));
+    }
+
+    @Test
+    public void setUpGivenBeforeIsFalseThenDoesNothingBefore() throws Exception {
+        // Given
+        final PrePostClean instance = new PrePostClean(false);
+        final AbstractBuild mockBuild = mock(AbstractBuild.class);
+        final Launcher mockLauncher = mock(Launcher.class);
+        final BuildListener mockListener = mock(BuildListener.class);
+
+        // When
+        instance.setUp(mockBuild, mockLauncher, mockListener);
+
+        // Then
+        verifyNoMoreInteractions(mockBuild, mockLauncher, mockListener);
+    }
+
+    @Test
+    public void setUpGivenBeforeIsFalseAndNotRoamingThenCleansOnlineMatchingNodesDuringTeardown() throws Exception {
+        // Given
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.setBefore(false);
+        final AbstractBuild mockBuild = mock(AbstractBuild.class, "mockBuild");
+        final Launcher mockLauncher = mock(Launcher.class);
+        final BuildListener mockListener = mock(BuildListener.class, "mockListener");
+        when(mockListener.getLogger()).thenReturn(System.out);
+        final AbstractProject mockProject = mock(AbstractProject.class,
+                withSettings().name("mockProject").extraInterfaces(TopLevelItem.class));
+        final Label mockAssignedLabel = mock(Label.class, "mockAssignedLabel");
+        final String node1Name = "nodeA1-current";
+        final String node2Name = "nodeA2";
+        final String node3Name = "nodeA3";
+        final String node4Name = "nodeA4-offline";
+        final Node mockNode1 = mockNode("mockNode1", node1Name, true);
+        final Node mockNode2 = mockNode("mockNode2", node2Name, true);
+        final Node mockNode3 = mockNode("mockNode3", node3Name, true);
+        final Node mockNode4 = mockNode("mockNode4", node4Name, false);
+        final Set<Node> setOfMockNodes = ImmutableSet.of(mockNode1, mockNode2, mockNode3, mockNode4);
+        final String ws = "/workspaces/myBuild";
+        final FilePath node1ws = mockNode1.createPath(ws);
+        final FilePath node2ws = mockNode2.createPath(ws);
+        final FilePath node3ws = mockNode3.createPath(ws);
+        when(mockNode1.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(node1ws);
+        when(mockNode2.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(node2ws);
+        when(mockNode3.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(node3ws);
+        when(mockNode4.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(null); // we're offline
+        when(mockBuild.getBuiltOnStr()).thenReturn(node1Name);
+        when(mockBuild.getProject()).thenReturn(mockProject);
+        when(mockProject.getAssignedLabel()).thenReturn(mockAssignedLabel);
+        when(mockAssignedLabel.getNodes()).thenReturn(setOfMockNodes);
+        final Environment env = instance.setUp(mockBuild, mockLauncher, mockListener);
+        verifyNoMoreInteractions(mockBuild, mockLauncher, mockListener, instance.mock);
+
+        // When
+        env.tearDown(mockBuild, mockListener);
+
+        // Then
+        final InOrder inOrder = inOrder(instance.mock);
+        // not expecting node1 to be cleaned as that's the current node
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node2Name, node2ws);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node3Name, node3ws);
+        // not expecting node4 to be cleaned as it's offline
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void setUpGivenBeforeIsTrueAndNotRoamingThenCleansOnlineMatchingNodesBeforeAndNotAfter() throws Exception {
+        // Given
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.setBefore(true);
+        final AbstractBuild mockBuild = mock(AbstractBuild.class, "mockBuild");
+        final Launcher mockLauncher = mock(Launcher.class);
+        final BuildListener mockListener = mock(BuildListener.class, "mockListener");
+        when(mockListener.getLogger()).thenReturn(System.out);
+        final AbstractProject mockProject = mock(AbstractProject.class,
+                withSettings().name("mockProject").extraInterfaces(TopLevelItem.class));
+        final Label mockAssignedLabel = mock(Label.class, "mockAssignedLabel");
+        final String node1Name = "nodeA1-current";
+        final String node2Name = "nodeA2";
+        final String node3Name = "nodeA3";
+        final String node4Name = "nodeA4-offline";
+        final String node5Name = "nodeA5-offline";
+        final Node mockNode1 = mockNode("mockNode1", node1Name, true);
+        final Node mockNode2 = mockNode("mockNode2", node2Name, true);
+        final Node mockNode3 = mockNode("mockNode3", node3Name, true);
+        final Node mockNode4 = mockNode("mockNode4", node4Name, false);
+        final Node mockNode5 = mockNode("mockNode5", node5Name, false);
+        final Set<Node> setOfMockNodes = ImmutableSet.of(mockNode1, mockNode2, mockNode3, mockNode4, mockNode5);
+        final String ws = "/workspaces/myBuild";
+        final FilePath node1ws = mockNode1.createPath(ws);
+        final FilePath node2ws = mockNode2.createPath(ws);
+        final FilePath node3ws = mockNode3.createPath(ws);
+        when(mockNode1.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(node1ws);
+        when(mockNode2.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(node2ws);
+        when(mockNode3.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(node3ws);
+        when(mockNode4.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(null); // we're offline
+        when(mockNode5.getWorkspaceFor((TopLevelItem) mockProject)).thenReturn(null); // we're offline
+        when(mockBuild.getBuiltOnStr()).thenReturn(node1Name);
+        when(mockBuild.getProject()).thenReturn(mockProject);
+        when(mockProject.getAssignedLabel()).thenReturn(mockAssignedLabel);
+        when(mockAssignedLabel.getNodes()).thenReturn(setOfMockNodes);
+
+        // When
+        final Environment env = instance.setUp(mockBuild, mockLauncher, mockListener);
+
+        // Then
+        final InOrder inOrder = inOrder(instance.mock);
+        // not expecting node1 to be cleaned as that's the current node
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node2Name, node2ws);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node3Name, node3ws);
+        // not expecting node4 to be cleaned as it's offline
+        // not expecting node5 to be cleaned as it's offline
+        inOrder.verifyNoMoreInteractions();
+        env.tearDown(mockBuild, mockListener);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void setUpGivenBeforeIsTrueAndRoamingThenSkips() throws Exception {
+        // Given
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.setBefore(true);
+        final AbstractBuild mockBuild = mock(AbstractBuild.class, "mockBuild");
+        final Launcher mockLauncher = mock(Launcher.class);
+        final BuildListener mockListener = mock(BuildListener.class, "mockListener");
+        when(mockListener.getLogger()).thenReturn(System.out);
+        final AbstractProject mockProject = mock(AbstractProject.class,
+                withSettings().name("mockProject").extraInterfaces(TopLevelItem.class));
+        when(mockBuild.getBuiltOnStr()).thenReturn("someNode");
+        when(mockBuild.getProject()).thenReturn(mockProject);
+        when(mockProject.getAssignedLabel()).thenReturn(null); // roaming
+
+        // When
+        final Environment env = instance.setUp(mockBuild, mockLauncher, mockListener);
+
+        // Then
+        verifyNoMoreInteractions(instance.mock);
+        env.tearDown(mockBuild, mockListener);
+        verifyNoMoreInteractions(instance.mock);
+    }
+
+    private static Node mockNode(final String mockName, final String nodeName, boolean nodeIsOnline) {
+        return mockNode(Node.class, mockName, nodeName, nodeIsOnline);
+    }
+
+    private static <T extends Node> T mockNode(final Class<T> type, final String mockName, final String nodeName,
+            boolean nodeIsOnline) {
+        final T m = mock(type, mockName);
+        when(m.getNodeName()).thenReturn(nodeName);
+        if (nodeIsOnline) {
+            final VirtualChannel mvc = type == Jenkins.class ? null : mock(VirtualChannel.class, mockName + "_vc");
+            when(m.createPath(anyString())).thenAnswer(new Answer<FilePath>() {
+                @Override
+                public FilePath answer(final InvocationOnMock invocation) throws Throwable {
+                    final String remotePath = (String) invocation.getArguments()[0];
+                    return new FilePath(mvc, remotePath);
+                }
+            });
+        } else {
+            when(m.createPath(anyString())).thenReturn(null);
+        }
+        return m;
+    }
+
+    private interface IMockableMethods {
+        void deleteWorkspaceOn(BuildListener listener, String nodeName, FilePath fp) throws InterruptedException;
+    }
+
+    class TestPrePostClean extends PrePostClean {
+        final IMockableMethods mock = mock(IMockableMethods.class);
+
+        @Override
+        void deleteWorkspaceOn(BuildListener listener, String nodeName, FilePath fp) throws InterruptedException {
+            mock.deleteWorkspaceOn(listener, nodeName, fp);
+        }
+    }
+}


### PR DESCRIPTION
* WebUI: Wrap 'before' field in a <f:advanced> box.
* WebUI: Added help.
* WebUI: Made text localizable.
* Config: Deprecated 'behind' field as it's always !before.
* Config: Added default constructor and DataBoundSetter.
* Build: Capitalised first letter of lines logged.
* Build: Don't catch & suppress InterruptedException.
* Dev: gitignore work folder as that's where mvn hpi:run puts its data.
* Dev: reformat code to use 4 spaces instead of tabs for indentation.
* Dev: added simple unit-test.
* Dev: removed @SuppressWarnings("rawtypes") where possible.
* Dev: combined multiple catches into multi-catch clause.
* Docs: Shortened plugin description.

There's no change in actual functionality here, it's just a code tidy-up prior to me doing actual functional changes.