### PR TITLE
Stability & performance enhancements

### DIFF
--- a/src/main/java/de/jamba/hudson/plugin/wsclean/CommonConfig.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/CommonConfig.java
@@ -1,0 +1,220 @@
+package de.jamba.hudson.plugin.wsclean;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.annotation.Nonnull;
+
+import org.jvnet.localizer.Localizable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+
+import hudson.Extension;
+import hudson.util.FormValidation;
+import jenkins.model.GlobalConfiguration;
+
+@Extension
+public class CommonConfig extends GlobalConfiguration {
+    /** @return the singleton instance */
+    public static CommonConfig get() {
+        return GlobalConfiguration.all().get(CommonConfig.class);
+    }
+
+    private static final char LINE_SEPARATOR = '\n';
+    private static final Joiner LINE_JOINER = Joiner.on(LINE_SEPARATOR).skipNulls();
+    private static final Splitter LINE_SPLITTER = Splitter.on(LINE_SEPARATOR).omitEmptyStrings();
+
+    public static enum NodeSelection {
+        LABEL_ONLY(true, false, Messages._NodeSelection_LABEL_ONLY_displayName()), // default
+        HISTORY_ONLY(false, true, Messages._NodeSelection_HISTORY_ONLY_displayName()),
+        LABEL_AND_HISTORY(true, true, Messages._NodeSelection_LABEL_AND_HISTORY_displayName());
+        private final boolean labels;
+        private final boolean history;
+        private final Localizable description;
+
+        private NodeSelection(boolean labels, boolean history, Localizable description) {
+            this.labels = labels;
+            this.history = history;
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description.toString();
+        }
+
+        public boolean getUseLabels() {
+            return labels;
+        }
+
+        public boolean getUseHistory() {
+            return history;
+        }
+    }
+
+    private static final NodeSelection DEFAULT_NODESELECTION = NodeSelection.LABEL_ONLY;
+    private static final boolean DEFAULT_SKIPROAMING = true; // legacy default
+    private static final boolean DEFAULT_PARALLEL = true;
+    private static final String[] DEFAULT_NODENAMESTOSKIP = new String[0];
+    private static final long DEFAULT_TIMEOUTINMILLISECONDS = 15L * 60L * 1000L; // 15 minutes
+    private NodeSelection nodeSelection = null; // our getter will return the default
+    private boolean skipRoaming = DEFAULT_SKIPROAMING;
+    private boolean parallel = DEFAULT_PARALLEL;
+    private String[] nodeNamesToSkip = DEFAULT_NODENAMESTOSKIP;
+    private transient Pattern[] nodeNamesToSkipPatterns;
+    private long timeoutInMilliseconds = DEFAULT_TIMEOUTINMILLISECONDS;
+
+    public CommonConfig() {
+        // When Jenkins is restarted, load any saved configuration from disk.
+        load();
+    }
+
+    public @Nonnull NodeSelection getNodeSelection() {
+        return nodeSelection == null ? DEFAULT_NODESELECTION : nodeSelection;
+    }
+
+    @DataBoundSetter
+    public void setNodeSelection(NodeSelection nodeSelection) {
+        this.nodeSelection = nodeSelection;
+        save();
+    }
+
+    public boolean getSkipRoaming() {
+        return skipRoaming;
+    }
+
+    @DataBoundSetter
+    public void setSkipRoaming(boolean skipRoaming) {
+        this.skipRoaming = skipRoaming;
+        save();
+    }
+
+    public boolean getParallel() {
+        return parallel;
+    }
+
+    @DataBoundSetter
+    public void setParallel(boolean parallel) {
+        this.parallel = parallel;
+        save();
+    }
+
+    public @Nonnull String[] getNodeNamesToSkip() {
+        return nodeNamesToSkip == null ? new String[0] : Arrays.copyOf(nodeNamesToSkip, nodeNamesToSkip.length);
+    }
+
+    public String getNodeNamesToSkipString() {
+        return LINE_JOINER.join(getNodeNamesToSkip());
+    }
+
+    /**
+     * Gets {@link #getNodeNamesToSkip()} as a series of {@link Pattern}s. Any
+     * values of {@link #getNodeNamesToSkip()} that aren't valid will be silently
+     * omitted.
+     * 
+     * @return An array of {@link Pattern}s. This will not be null.
+     */
+    @Restricted(NoExternalUse.class)
+    Pattern[] getNodeNamesToSkipPatterns() {
+        return nodeNamesToSkipPatterns == null ? new Pattern[0] : nodeNamesToSkipPatterns;
+    }
+
+    @DataBoundSetter
+    public void setNodeNamesToSkip(String[] nodeNamesToSkip) {
+        final List<Pattern> patterns;
+        if (nodeNamesToSkip == null) {
+            patterns = Lists.newArrayList();
+            this.nodeNamesToSkip = new String[0];
+        } else {
+            final int length = nodeNamesToSkip.length;
+            patterns = Lists.newArrayListWithCapacity(length);
+            for (final String nodeNameToSkip : nodeNamesToSkip) {
+                try {
+                    final Pattern p = Pattern.compile(nodeNameToSkip);
+                    patterns.add(p);
+                } catch (PatternSyntaxException ex) {
+                    // ignore and skip it
+                }
+            }
+            this.nodeNamesToSkip = Arrays.copyOf(nodeNamesToSkip, length);
+        }
+        this.nodeNamesToSkipPatterns = patterns.toArray(new Pattern[patterns.size()]);
+        save();
+    }
+
+    @DataBoundSetter
+    public void setNodeNamesToSkipString(String nodeNamesToSkipString) {
+        setNodeNamesToSkip(splitAndFilterEmpty(nodeNamesToSkipString));
+    }
+
+    public long getTimeoutInMilliseconds() {
+        return timeoutInMilliseconds < 0L ? 0L : timeoutInMilliseconds;
+    }
+
+    @DataBoundSetter
+    public void setTimeoutInMilliseconds(long timeoutInMilliseconds) {
+        this.timeoutInMilliseconds = timeoutInMilliseconds;
+    }
+
+    public FormValidation doCheckSkipRoaming(@QueryParameter boolean value, @QueryParameter String nodeSelection) {
+        NodeSelection nodeSelectionEnum;
+        try {
+            nodeSelectionEnum = NodeSelection.valueOf(nodeSelection);
+        } catch (IllegalArgumentException ex) {
+            nodeSelectionEnum = null;
+        }
+        if (NodeSelection.HISTORY_ONLY.equals(nodeSelectionEnum)) {
+            return FormValidation.warning(Messages.CommonConfig_skipRoamingIgnores());
+        }
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckNodeNamesToSkipString(@QueryParameter String value) {
+        final String[] values = splitAndFilterEmpty(value);
+        final List<String> warnings = Lists.newArrayList();
+        final List<String> errors = Lists.newArrayList();
+        for (int i = 0; i < values.length; i++) {
+            final int number = i + 1;
+            final String thisValue = values[i];
+            if (thisValue.startsWith(" ")) {
+                warnings.add(Messages.CommonConfig_nodeNamesToSkip_whitespaceFirst(number));
+            }
+            if (thisValue.endsWith(" ")) {
+                warnings.add(Messages.CommonConfig_nodeNamesToSkip_whitespaceLast(number));
+            }
+            try {
+                Pattern.compile(thisValue);
+            } catch (PatternSyntaxException ex) {
+                errors.add(Messages.CommonConfig_nodeNamesToSkip_invalid(number, ex.getMessage()));
+            }
+        }
+        if (!errors.isEmpty()) {
+            return FormValidation.error(errors.get(0));
+        }
+        if (!warnings.isEmpty()) {
+            return FormValidation.warning(warnings.get(0));
+        }
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckTimeoutInMilliseconds(@QueryParameter String value) {
+        return FormValidation.validateNonNegativeInteger(value);
+    }
+
+    private static String[] splitAndFilterEmpty(String s) {
+        final List<String> result = Lists.newArrayList();
+        if (s != null) {
+            for (final String o : LINE_SPLITTER.split(s)) {
+                result.add(o);
+            }
+        }
+        return result.toArray(new String[result.size()]);
+    }
+}

--- a/src/main/java/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty.java
@@ -1,0 +1,32 @@
+package de.jamba.hudson.plugin.wsclean;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+
+/**
+ * Jenkins slave {@link NodeProperty} that, when set, causes
+ * {@link PrePostClean} to skip the {@link Node}.
+ */
+public class DisablePrePostCleanNodeProperty extends NodeProperty<Node> {
+
+    @DataBoundConstructor
+    public DisablePrePostCleanNodeProperty() {
+    }
+
+    @Extension
+    public static final class NodePropertyDescriptorImpl extends NodePropertyDescriptor {
+
+        public NodePropertyDescriptorImpl() {
+            super(DisablePrePostCleanNodeProperty.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.DisablePrePostCleanNodeProperty_displayName();
+        }
+    }
+}

--- a/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
@@ -277,7 +277,7 @@ public class PrePostClean extends BuildWrapper {
         AbstractProject<?, ?> project = build.getProject();
         Label assignedLabel = project.getAssignedLabel();
         if (assignedLabel == null && skipRoaming) {
-            listener.getLogger().println("skipping roaming project.");
+            listener.getLogger().println("Skipping roaming project.");
             return;
         }
         Set<Node> nodesForLabel = assignedLabel != null ? assignedLabel.getNodes() : getAllNonexclusiveNodes(jenkins);

--- a/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
@@ -1,29 +1,55 @@
 package de.jamba.hudson.plugin.wsclean;
 
+import static de.jamba.hudson.plugin.wsclean.TaskUtils.runWithTimeout;
+import static de.jamba.hudson.plugin.wsclean.TaskUtils.runWithoutTimeout;
+import static de.jamba.hudson.plugin.wsclean.TaskUtils.waitUntilAllAreDone;
+
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.TreeMultimap;
+
+import de.jamba.hudson.plugin.wsclean.CommonConfig.NodeSelection;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.Computer;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.TopLevelItem;
 import hudson.remoting.RequestAbortedException;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import hudson.util.FormValidation;
+import hudson.util.RunList;
+import jenkins.model.Jenkins;
 
 public class PrePostClean extends BuildWrapper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrePostClean.class);
 
-    public boolean before;
+    private boolean before;
 
     @SuppressWarnings("unused")
     @Deprecated
@@ -38,6 +64,12 @@ public class PrePostClean extends BuildWrapper {
         setBefore(before);
     }
 
+    /**
+     * If set, we clean at the start of the build instead of at the end of the
+     * build.
+     * 
+     * @return true if we run before the build.
+     */
     public boolean isBefore() {
         return before;
     }
@@ -47,74 +79,425 @@ public class PrePostClean extends BuildWrapper {
         this.before = before;
     }
 
+    // Main entry point to our functionality.
+    // This gets called when the build starts, and returns a hook that's run when
+    // the build finishes, allowing our code to get called.
     @SuppressWarnings("rawtypes")
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener)
             throws IOException, InterruptedException {
         final boolean runAtStart = isBefore();
         final boolean runAtEnd = !runAtStart;
+        final CommonConfig commonConfig = CommonConfig.get();
+        final boolean skipRoaming = commonConfig.getSkipRoaming();
+        final NodeSelection nodeSelectionMethod = commonConfig.getNodeSelection();
+        final Pattern[] nodeNamesToSkip = commonConfig.getNodeNamesToSkipPatterns();
+        final boolean parallel = commonConfig.getParallel();
+        final long timeoutInMs = commonConfig.getTimeoutInMilliseconds();
+        final Jenkins jenkins = Jenkins.getInstance();
+        final ExecutorService parallelExecutor = Computer.threadPoolForRemoting;
+        LOGGER.info(
+                "setUp({},,): runAtStart={}, runAtEnd={}, nodeSelectionMethod={}, skipRoaming={}, nodeNamesToSkip={}, parallel={}, timeoutInMs={}",
+                build, runAtStart, runAtEnd, nodeSelectionMethod.name(), skipRoaming, Arrays.asList(nodeNamesToSkip),
+                parallel, timeoutInMs);
         // TearDown
         class TearDownImpl extends Environment {
             @Override
             public boolean tearDown(AbstractBuild build, BuildListener listener)
                     throws IOException, InterruptedException {
                 if (runAtEnd) {
-                    executeOnSlaves(build, listener);
+                    executeOnSlaves("Post", jenkins, parallelExecutor, build, listener, nodeSelectionMethod,
+                            skipRoaming, nodeNamesToSkip, parallel, timeoutInMs);
                 }
                 return super.tearDown(build, listener);
             }
         }
 
         if (runAtStart) {
-            executeOnSlaves(build, listener);
+            executeOnSlaves("Pre", jenkins, parallelExecutor, build, listener, nodeSelectionMethod, skipRoaming,
+                    nodeNamesToSkip, parallel, timeoutInMs);
         }
         return new TearDownImpl();
     }
 
-    private void executeOnSlaves(AbstractBuild<?, ?> build, BuildListener listener) throws InterruptedException {
-        listener.getLogger().println("Run PrePostClean");
+    /**
+     * Does the clean-up, and says so.
+     * 
+     * @param preOrPost       String "Pre" or "Post". Only affects logging output.
+     * @param build           The build this action is part of.
+     * @param listener        The build output log we can append to.
+     * @param jenkins         Maps node names to nodes.
+     * @param executor        Means of running multiple threads in parallel.
+     * @param nodeSelection   Method we're going to use to decide what to clean.
+     * @param nodeNamesToSkip List of regexes matching node names to skip.
+     * @param parallel        If true we do the deletion in parallel, if false we do
+     *                        each node in sequence.
+     * @param timeoutInMs     If >0, timeout for the deletion in milliseconds.
+     * @throws InterruptedException if we are interrupted before we are complete.
+     */
+    @Restricted(NoExternalUse.class) // package-level to avoid accessor class
+    void executeOnSlaves(String preOrPost, Jenkins jenkins, ExecutorService executor, AbstractBuild<?, ?> build,
+            BuildListener listener, NodeSelection nodeSelection, boolean skipRoaming, Pattern[] nodeNamesToSkip,
+            boolean parallel, long timeoutInMs) throws InterruptedException {
+        listener.getLogger().println(preOrPost + "-build clean running...");
+        String result = "abandoned";
+        try {
+            final boolean success = cleanUp(jenkins, executor, build, listener, nodeSelection, skipRoaming,
+                    nodeNamesToSkip, parallel, timeoutInMs);
+            result = success ? "completed" : "failed";
+        } finally {
+            listener.getLogger().println(preOrPost + "-build clean " + result + ".");
+        }
+    }
+
+    private boolean cleanUp(Jenkins jenkins, ExecutorService executor, AbstractBuild<?, ?> build,
+            BuildListener listener, NodeSelection nodeSelection, boolean skipRoaming, Pattern[] nodeNameRegexsToSkip,
+            boolean parallel, long timeoutInMs) throws InterruptedException {
+        LOGGER.debug("cleanUp({}) started", build);
+        final Multimap<String, String> workspacesToBeRemoved = calculateWssForRemoval(jenkins, build, listener,
+                nodeSelection, skipRoaming);
+        LOGGER.debug("cleanUp({}): calculateWssForRemoval(,,,{},{})={}", build, nodeSelection, skipRoaming,
+                workspacesToBeRemoved);
+        final List<String> nodesToSkipDueToTheirName = getMatching(workspacesToBeRemoved.keySet(),
+                nodeNameRegexsToSkip);
+        LOGGER.debug("cleanUp({}): nodesToSkipDueToTheirName={}", build, nodesToSkipDueToTheirName);
+        workspacesToBeRemoved.keySet().removeAll(nodesToSkipDueToTheirName);
+        final List<String> nodesToSkipDueToNodeProperty = getNodesWithDisableProperty(workspacesToBeRemoved.keySet(),
+                jenkins);
+        LOGGER.debug("cleanUp({}): nodesToSkipDueToNodeProperty={}", build, nodesToSkipDueToNodeProperty);
+        workspacesToBeRemoved.keySet().removeAll(nodesToSkipDueToNodeProperty);
+        class CleanOldWorkspaces implements Callable<Void> {
+            @Override
+            public Void call() throws InterruptedException {
+                if (parallel) {
+                    LOGGER.debug("cleanUp({}): deleteWssInParallel...", build);
+                    deleteWssInParallel(build, jenkins, executor, workspacesToBeRemoved, listener);
+                } else {
+                    LOGGER.debug("cleanUp({}): deleteWssInSeries...", build);
+                    deleteWssInSeries(build, jenkins, workspacesToBeRemoved, listener);
+                }
+                LOGGER.debug("cleanUp({}): deleted.", build);
+                return null;
+            }
+        }
+        final Callable<Void> deletionTask = new CleanOldWorkspaces();
+        boolean success = false;
+        if (timeoutInMs > 0L) {
+            LOGGER.debug("cleanUp({}): using timeout of {}.", build, timeoutInMs);
+            try {
+                runWithTimeout(executor, timeoutInMs, deletionTask);
+                success = true;
+            } catch (TimeoutException e) {
+                listener.getLogger().println("Clean did not complete within " + timeoutInMs + " milliseconds.");
+            }
+        } else {
+            runWithoutTimeout(deletionTask);
+            success = true;
+        }
+        LOGGER.debug("cleanUp({}): completed.", build);
+        return success;
+    }
+
+    /**
+     * Calculates what workspaces we should consider for removal, taking
+     * <em>everything</em> into consideration.
+     * 
+     * @param jenkins       Contains all our possible nodes.
+     * @param build         Our current build.
+     * @param listener      User-facing log where we can log progress reports to the
+     *                      build.
+     * @param nodeSelection Says how we'll decide.
+     * @param skipRoaming   If we should ignore "nodes matching label expression" if
+     *                      we have no label expression.
+     * @return A map of node names to lists of workspace locations.
+     */
+    private Multimap<String, String> calculateWssForRemoval(Jenkins jenkins, AbstractBuild<?, ?> build,
+            BuildListener listener, NodeSelection nodeSelection, boolean skipRoaming) {
+        final Multimap<String, String> wssForRemovalFromLabels;
+        if (nodeSelection.getUseLabels()) {
+            wssForRemovalFromLabels = TreeMultimap.create();
+            findPossibleWssFromJobLabel(wssForRemovalFromLabels, jenkins, build, listener, skipRoaming);
+        } else {
+            wssForRemovalFromLabels = null;
+        }
+        final Multimap<String, String> oldWssFromHistory;
+        final Multimap<String, String> currentWssFromHistory;
+        final Set<String> nodeNamesOfDeadNodes;
+        if (nodeSelection.getUseHistory() || build.getProject().isConcurrentBuild()) {
+            oldWssFromHistory = TreeMultimap.create();
+            currentWssFromHistory = TreeMultimap.create();
+            nodeNamesOfDeadNodes = Sets.newTreeSet();
+            findWssFromBuildHistory(currentWssFromHistory, oldWssFromHistory, nodeNamesOfDeadNodes, build);
+        } else {
+            oldWssFromHistory = null;
+            currentWssFromHistory = null;
+            nodeNamesOfDeadNodes = null;
+        }
+        // Now work out what locations are safe to remove
+        final Multimap<String, String> workspacesToBeRemoved = TreeMultimap.create();
+        // Include stuff from labels if we want to
+        if (nodeSelection.getUseLabels()) {
+            workspacesToBeRemoved.putAll(wssForRemovalFromLabels);
+        }
+        // Include stuff from history if we want to
+        if (nodeSelection.getUseHistory()) {
+            workspacesToBeRemoved.putAll(oldWssFromHistory);
+            for (final String offlineNode : nodeNamesOfDeadNodes) {
+                workspacesToBeRemoved.removeAll(offlineNode);
+            }
+        }
+        // Exclude currently-running builds if we know them
+        if (currentWssFromHistory != null) {
+            // We looked for all currently-running builds, which includes us.
+            for (final Map.Entry<String, String> workspaceCurrentlyInUse : currentWssFromHistory.entries()) {
+                workspacesToBeRemoved.remove(workspaceCurrentlyInUse.getKey(), workspaceCurrentlyInUse.getValue());
+            }
+        }
+        return workspacesToBeRemoved;
+    }
+
+    /**
+     * Uses the job label expression to determine what slave nodes this build could
+     * run on and, from that, guess what workspaces we should delete. Note: This
+     * does not take concurrent builds into account.
+     * 
+     * @param result      Where to put the workspaces we identify.
+     * @param jenkins     Used to determine all possible nodes if we are a roaming
+     *                    build and skipRoaming is false.
+     * @param build       Our current build.
+     * @param listener    User-facing log where we can log progress reports to the
+     *                    build.
+     * @param skipRoaming If we should return nothing (instead of everything) if we
+     *                    have no label expression.
+     */
+    private void findPossibleWssFromJobLabel(final Multimap<String, String> result, Jenkins jenkins,
+            AbstractBuild<?, ?> build, BuildListener listener, boolean skipRoaming) {
         // select actual running label
         String runNode = build.getBuiltOnStr();
-
-        listener.getLogger().println("Running on " + toNormalizedNodeName(runNode));
-
         AbstractProject<?, ?> project = build.getProject();
         Label assignedLabel = project.getAssignedLabel();
-        if (assignedLabel == null) {
-            listener.getLogger().println("Skipping roaming project.");
+        if (assignedLabel == null && skipRoaming) {
+            listener.getLogger().println("skipping roaming project.");
             return;
         }
-        Set<Node> nodesForLabel = assignedLabel.getNodes();
+        Set<Node> nodesForLabel = assignedLabel != null ? assignedLabel.getNodes() : getAllNonexclusiveNodes(jenkins);
+        LOGGER.debug("calculatePotentialWssFromJobLabel(,{},{}): assignedLabel={} evaluates to nodesForLabel={}", build,
+                skipRoaming, assignedLabel == null ? null : assignedLabel.getExpression(), nodesForLabel);
         if (nodesForLabel != null) {
             for (Node node : nodesForLabel) {
                 String nodeName = node.getNodeName();
                 if (!runNode.equals(nodeName)) {
                     String normalizedName = toNormalizedNodeName(nodeName);
-                    listener.getLogger().println("Cleaning on " + normalizedName);
-                    deleteWorkspaceOn(project, listener, node, normalizedName);
+                    String folderOnNode = getWorkspaceOn(project, listener, node, normalizedName);
+                    LOGGER.debug("calculatePotentialWssFromJobLabel(,{},{}): Node={}, folder={}", build, skipRoaming,
+                            nodeName, folderOnNode);
+                    if (folderOnNode != null) {
+                        result.put(nodeName, folderOnNode);
+                    }
+                } else {
+                    LOGGER.debug("calculatePotentialWssFromJobLabel(,{},{}): Node={} is current node, so excluding",
+                            build, skipRoaming, nodeName);
                 }
             }
         }
     }
 
-    private void deleteWorkspaceOn(AbstractProject<?, ?> project, BuildListener listener, Node node, String nodeName)
-            throws InterruptedException {
+    /**
+     * Uses the old build history to determine what workspaces (on what slave nodes)
+     * we should delete.
+     * 
+     * @param wssCurrentlyInUse    Where to record workspaces that are currently in
+     *                             use.
+     * @param wssPreviouslyUsed    Where to record workspaces that are no longer in
+     *                             use.
+     * @param nodeNamesOfDeadNodes Where to record nodes which aren't online so we
+     *                             need to avoid touching them at all.
+     * @param build                The build we're doing this on.
+     */
+    private void findWssFromBuildHistory(Multimap<String, String> wssCurrentlyInUse,
+            Multimap<String, String> wssPreviouslyUsed, Set<String> nodeNamesOfDeadNodes, AbstractBuild<?, ?> build) {
+        final AbstractProject<?, ?> project = build.getProject();
+        // First, figure out the overall build history
+        final RunList<?> builds = project.getBuilds();
+        for (final Object historyEntry : builds) {
+            if (!(historyEntry instanceof AbstractBuild)) {
+                LOGGER.debug("calculateUnusedWssFromBuildHistory({}): {} is not AbstractBuild", build, historyEntry);
+                continue;
+            }
+            final AbstractBuild<?, ?> historicalBuild = (AbstractBuild<?, ?>) historyEntry;
+            if (historicalBuild.hasntStartedYet()) {
+                LOGGER.debug("calculateUnusedWssFromBuildHistory({}): {} has not started", build, historicalBuild);
+                continue; // no node or ws assigned yet
+            }
+            final String nodeItRanOn = Util.fixNull(historicalBuild.getBuiltOnStr());
+            final Node node = historicalBuild.getBuiltOn();
+            if (node == null) {
+                // Node no longer exists
+                LOGGER.debug("calculateUnusedWssFromBuildHistory({}): {} ran on node {} which is deleted.", build,
+                        historicalBuild, nodeItRanOn);
+                nodeNamesOfDeadNodes.add(nodeItRanOn);
+                continue;
+            }
+            final FilePath wsOrNull = historicalBuild.getWorkspace();
+            if (wsOrNull == null) {
+                // Node is offline
+                LOGGER.debug(
+                        "calculateUnusedWssFromBuildHistory({}): {} ran on node {} which is offline so ws unavailable.",
+                        build, historicalBuild, nodeItRanOn);
+                nodeNamesOfDeadNodes.add(nodeItRanOn);
+                continue;
+            }
+            final boolean buildIsNotFinished = historicalBuild.isBuilding() || historicalBuild.getExecutor() != null;
+            final String folderOnNode = wsOrNull.getRemote();
+            LOGGER.debug("calculateUnusedWssFromBuildHistory({}): Unfinished={} {} ran on node {} in folder {}.", build,
+                    buildIsNotFinished, historicalBuild, nodeItRanOn, folderOnNode);
+            if (buildIsNotFinished) {
+                wssCurrentlyInUse.put(nodeItRanOn, folderOnNode);
+            } else {
+                wssPreviouslyUsed.put(nodeItRanOn, folderOnNode);
+            }
+        }
+    }
+
+    /**
+     * Deletes workspaces, one workspace at a time, all in this thread.
+     * 
+     * @param build                 The build this is for. This is only used for
+     *                              diagnostic logging.
+     * @param nodeContainer         The Jenkins node that can turn node names into
+     *                              Nodes.
+     * @param workspacesToBeRemoved The set of workspaces to be removed.
+     * @param listener              User-facing log where we can log progress
+     *                              reports to the build.
+     * @throws InterruptedException if we are interrupted (e.g. if the build is
+     *                              cancelled).
+     */
+    @Restricted(NoExternalUse.class)
+    void deleteWssInSeries(AbstractBuild<?, ?> build, Jenkins nodeContainer,
+            Multimap<String, String> workspacesToBeRemoved, BuildListener listener) throws InterruptedException {
+        for (final Map.Entry<String, ? extends Iterable<String>> e : workspacesToBeRemoved.asMap().entrySet()) {
+            final Iterable<String> foldersToDelete = e.getValue();
+            final String nodeName = e.getKey();
+            final String normalizedNodeName = toNormalizedNodeName(nodeName);
+            final Node node = getNode(nodeContainer, nodeName);
+            if (node == null) {
+                LOGGER.debug("deleteWssInSeries({}): node==null for normalizedNodeName={}, foldersToDelete={}", build,
+                        normalizedNodeName, foldersToDelete);
+                continue; // it's gone while we were mid-calculation
+            }
+            for (final String folderToDelete : foldersToDelete) {
+                final FilePath fp = node.createPath(folderToDelete);
+                if (fp == null) {
+                    LOGGER.debug("deleteWssInSeries({}): fp==null for normalizedNodeName={}, folderToDelete={}", build,
+                            normalizedNodeName, folderToDelete);
+                    continue; // it's gone offline while we were mid-calculation
+                }
+                listener.getLogger().println("Cleaning " + normalizedNodeName + " folder " + fp);
+                LOGGER.debug("deleteWssInSeries({}): deleting normalizedNodeName={}, folderToDelete={}", build,
+                        normalizedNodeName, folderToDelete);
+                deleteWorkspaceOn(build, listener, normalizedNodeName, fp);
+            }
+        }
+    }
+
+    /**
+     * Deletes workspaces, using a separate thread for each slave node affected so
+     * that all the slave nodes do their deletions in parallel.
+     * 
+     * @param build                 The build this is for. This is only used for
+     *                              diagnostic logging.
+     * @param nodeContainer         The Jenkins node that can turn node names into
+     *                              Nodes.
+     * @param parallelExecutor      Thread provider that'll be running the deletions
+     *                              for us.
+     * @param workspacesToBeRemoved The set of workspaces to be removed.
+     * @param listener              User-facing log where we can log progress
+     *                              reports to the build.
+     * @throws InterruptedException if we are interrupted (e.g. if the build is
+     *                              cancelled).
+     */
+    @Restricted(NoExternalUse.class)
+    void deleteWssInParallel(AbstractBuild<?, ?> build, Jenkins nodeContainer, ExecutorService parallelExecutor,
+            Multimap<String, String> workspacesToBeRemoved, BuildListener listener) throws InterruptedException {
+        final List<Future<?>> deletionTaskResults = Lists.newArrayList();
+        for (final Map.Entry<String, ? extends Iterable<String>> e : workspacesToBeRemoved.asMap().entrySet()) {
+            final Iterable<String> foldersToDelete = e.getValue();
+            final String nodeName = e.getKey();
+            final String normalizedNodeName = toNormalizedNodeName(nodeName);
+            final Node node = getNode(nodeContainer, nodeName);
+            if (node == null) {
+                LOGGER.debug("deleteWssInParallel({}): node==null for normalizedNodeName={}, foldersToDelete={}", build,
+                        normalizedNodeName, foldersToDelete);
+                continue; // it's gone while we were mid-calculation
+            }
+            class CleanFoldersOnOneNode implements Callable<Void> {
+                @Override
+                public Void call() throws Exception {
+                    try {
+                        for (final String folderToDelete : foldersToDelete) {
+                            final FilePath fp = node.createPath(folderToDelete);
+                            if (fp == null) {
+                                continue; // it's gone offline while we were mid-calculation
+                            }
+                            listener.getLogger().println("Cleaning " + normalizedNodeName + " folder " + fp);
+                            deleteWorkspaceOn(build, listener, normalizedNodeName, fp);
+                        }
+                    } catch (InterruptedException e) {
+                        listener.getLogger().println("Cleaning on " + normalizedNodeName + " was interrupted.");
+                    }
+                    return null;
+                }
+            }
+            final Callable<Void> task = new CleanFoldersOnOneNode();
+            LOGGER.debug("deleteWssInParallel({}): submitting task to delete normalizedNodeName={}, foldersToDelete={}",
+                    build, normalizedNodeName, foldersToDelete);
+            final Future<?> futureResult = parallelExecutor.submit(task);
+            deletionTaskResults.add(futureResult);
+        }
+        LOGGER.debug("deleteWssInParallel({}): waiting for {} deletions to complete", build,
+                deletionTaskResults.size());
+        try {
+            waitUntilAllAreDone(deletionTaskResults);
+            LOGGER.debug("deleteWssInParallel({}): wait complete", build);
+        } catch (InterruptedException ex) {
+            // if we're interrupted, we tell all our other tasks to abort.
+            for (Future<?> t : deletionTaskResults) {
+                t.cancel(true);
+            }
+            throw ex;
+        }
+    }
+
+    private String getWorkspaceOn(AbstractProject<?, ?> project, BuildListener listener, Node node, String nodeName) {
         if (project instanceof TopLevelItem) {
             FilePath fp = node.getWorkspaceFor((TopLevelItem) project);
             if (fp != null) {
-                deleteWorkspaceOn(listener, nodeName, fp);
+                return fp.getRemote();
             } else {
                 listener.getLogger().println("No workspace found on " + nodeName + ". Node is maybe offline.");
             }
         } else {
-            listener.getLogger().println("Project is no TopLevelItem!? Cannot determine other workspaces!");
+            listener.getLogger().println("Project is not TopLevelItem! Cannot determine other workspaces!");
         }
+        return null;
     }
 
-    /* This is only non-private for test purposes. */
+    /**
+     * This is only non-private for test purposes. Wipes the workspace at the given
+     * location, logging any problems.
+     * 
+     * @param build    The build this is for (used for logging only).
+     * @param listener Where to log progress/issues.
+     * @param nodeName Human-friendly name of the node we're working on (used for
+     *                 logging only).
+     * @param fp       The workspace to be wiped.
+     * @throws InterruptedException if we are interrupted.
+     */
     @Restricted(NoExternalUse.class) // unit-test only
-    void deleteWorkspaceOn(BuildListener listener, String nodeName, FilePath fp) throws InterruptedException {
+    void deleteWorkspaceOn(AbstractBuild<?, ?> build, BuildListener listener, String nodeName, FilePath fp)
+            throws InterruptedException {
         try {
+            LOGGER.trace("deleteWorkspaceOn({}): Deleting {} on node {}", build, fp.getRemote(), nodeName);
             fp.deleteContents();
         } catch (IOException | RequestAbortedException e) {
             listener.getLogger()
@@ -126,6 +509,56 @@ public class PrePostClean extends BuildWrapper {
     private static String toNormalizedNodeName(String nodeName) {
         final String normalizedNodeName = (nodeName == null || "".equals(nodeName)) ? "master" : nodeName;
         return normalizedNodeName;
+    }
+
+    private static Node getNode(Jenkins nodeContainer, String nodeName) {
+        if (nodeName.isEmpty()) {
+            return nodeContainer;
+        }
+        return nodeContainer.getNode(nodeName);
+    }
+
+    private static List<String> getMatching(Iterable<String> input, Pattern[] patternsToMatch) {
+        final List<String> result = Lists.newArrayList();
+        for (final String s : input) {
+            for (final Pattern p : patternsToMatch) {
+                if (p.matcher(s).matches()) {
+                    result.add(s);
+                    break; // go to next input string
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Set<Node> getAllNonexclusiveNodes(Jenkins jenkins) {
+        final Set<Node> result = Sets.newHashSet();
+        for (final Node n : jenkins.getNodes()) {
+            if (Node.Mode.NORMAL.equals(n.getMode())) {
+                result.add(n);
+            }
+        }
+        if (Node.Mode.NORMAL.equals(jenkins.getMode())) {
+            result.add(jenkins);
+        }
+        return result;
+    }
+
+    private static List<String> getNodesWithDisableProperty(Set<String> nodesToConsider, Jenkins jenkins) {
+        final List<String> result = Lists.newArrayList();
+        for (final Node n : jenkins.getNodes()) {
+            final String nodeName = n.getNodeName();
+            if (nodesToConsider.contains(nodeName)
+                    && n.getNodeProperty(DisablePrePostCleanNodeProperty.class) != null) {
+                result.add(nodeName);
+            }
+        }
+        final String nodeName = "";
+        if (nodesToConsider.contains(nodeName)
+                && jenkins.getNodeProperty(DisablePrePostCleanNodeProperty.class) != null) {
+            result.add(nodeName);
+        }
+        return result;
     }
 
     @Extension

--- a/src/main/java/de/jamba/hudson/plugin/wsclean/TaskUtils.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/TaskUtils.java
@@ -1,0 +1,109 @@
+package de.jamba.hudson.plugin.wsclean;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+public class TaskUtils {
+    /**
+     * Runs a task and returns its result, or throws {@link TimeoutException} if it
+     * took too long. If we get interrupted while waiting, or we time out, we'll
+     * cancel (interrupt) the task to tell it to quit ASAP.
+     * 
+     * @param timeoutInMs Max duration to allow it to run in milliseconds.
+     * @param task        The task to be run.
+     * @return The result of the task.
+     * @throws InterruptedException If we were interrupted or if the task itself was
+     *                              interrupted.
+     * @throws TimeoutException     If the task did not complete in time.
+     */
+    @Restricted(NoExternalUse.class)
+    static <T> T runWithTimeout(final ExecutorService threadpool, final long timeoutInMs, final Callable<T> task)
+            throws InterruptedException, TimeoutException {
+        final Future<T> futureResult = threadpool.submit(task);
+        try {
+            return futureResult.get(timeoutInMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException ex) {
+            final Throwable cause = ex.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof InterruptedException) {
+                throw (InterruptedException) cause;
+            }
+            throw new RuntimeException(cause);
+        } finally {
+            futureResult.cancel(true);
+        }
+    }
+
+    /**
+     * Runs a task and results its result, letting it run indefinitely.
+     * 
+     * @param task The task to be run.
+     * @return The result of the task.
+     * @throws InterruptedException If we were interrupted while we were running the
+     *                              task.
+     */
+    @Restricted(NoExternalUse.class)
+    static <T> T runWithoutTimeout(final Callable<T> task) throws InterruptedException {
+        try {
+            return task.call();
+        } catch (Exception ex) {
+            if (ex instanceof RuntimeException) {
+                throw (RuntimeException) ex;
+            }
+            if (ex instanceof InterruptedException) {
+                throw (InterruptedException) ex;
+            }
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Waits until multiple tasks are complete.
+     * 
+     * @param asyncTasks The tasks to be waited for.
+     * @throws InterruptedException if we are interrupted while we were waiting.
+     */
+    @Restricted(NoExternalUse.class)
+    static void waitUntilAllAreDone(Iterable<Future<?>> asyncTasks) throws InterruptedException {
+        final long millisecondsToWaitLongerEachTime = 50L;
+        final long maxMillisecondsToWaitBetweenPolls = 1000L;
+        final long millisecondsToWaitFirstTime = 50L;
+        long millisecondsToWaitThisTime = millisecondsToWaitFirstTime;
+        for (Future<?> incompleteTask = getFirstIncompleteTask(
+                asyncTasks); incompleteTask != null; incompleteTask = getFirstIncompleteTask(asyncTasks)) {
+            try {
+                incompleteTask.get(millisecondsToWaitThisTime, TimeUnit.MILLISECONDS);
+                // it completed (without error) - reset timeout duration
+                millisecondsToWaitThisTime = millisecondsToWaitFirstTime;
+            } catch (ExecutionException e) {
+                // it completed (with error) - reset timeout duration
+                millisecondsToWaitThisTime = millisecondsToWaitFirstTime;
+            } catch (TimeoutException e) {
+                // it did not complete - increase the timeout
+                millisecondsToWaitThisTime = Math.min(maxMillisecondsToWaitBetweenPolls,
+                        millisecondsToWaitThisTime + millisecondsToWaitLongerEachTime);
+            } catch (InterruptedException e) {
+                throw e;
+            }
+            // Note: If we are interrupted, we let that escape uncaught
+        }
+    }
+
+    private static <T extends Future<?>> T getFirstIncompleteTask(Iterable<T> asyncTasks) {
+        for (final T t : asyncTasks) {
+            if (!t.isDone()) {
+                return t;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/config.jelly
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/config.jelly
@@ -1,0 +1,28 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:section title="${%Distributed workspace clean}">
+
+        <f:entry title="${%Node cleaning criteria}" field="nodeSelection">
+            <f:enum>${it.description}</f:enum>
+        </f:entry>
+
+        <f:entry title="${%Skip roaming}" field="skipRoaming">
+            <f:checkbox/>
+        </f:entry>
+
+        <f:entry title="${%Concurrent cleanup}" field="parallel">
+            <f:checkbox/>
+        </f:entry>
+
+        <f:entry title="${%Nodes to ignore}" field="nodeNamesToSkipString">
+          <f:expandableTextbox />
+        </f:entry>
+
+        <f:entry title="${%Timeout in milliseconds}" field="timeoutInMilliseconds">
+            <f:textbox default="60000"/>
+        </f:entry>
+
+    </f:section>
+ 
+</j:jelly>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-nodeNamesToSkipString.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-nodeNamesToSkipString.html
@@ -1,0 +1,17 @@
+<div>
+    List of regular expressions naming nodes to be excluded from cleaning.
+    <p>Normally, a node property would be set on a node to indicate
+        that it should be excluded from cleanup activities. e.g.
+        dynamically-created nodes that are used once and then thrown away.
+        However, not all node technologies support node properties, so in this
+        case a set of regular expressions can be provided that will be matched
+        against the node name and, if any regex matches a node name, that node
+        will be excluded from cleanup activities.</p>
+    Each (non-empty) line must be a valid regular expression. e.g.
+    <code>^docker-.*$</code>
+    <p>
+        Note: For the purposes of this matching, the name of the master node
+        is the empty string not &quot;master&quot; so, if you want to exclude
+        the master node from cleaning, you'll need to include a line saying
+        <code>^$</code>
+</div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-nodeSelection.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-nodeSelection.html
@@ -1,0 +1,43 @@
+<div>
+    Specifies what information is used to decide what nodes (and where on
+    those nodes) are cleaned.
+    <dl>
+        <dt>Clean nodes that could be used</dt>
+        <dd>
+            The node labels are checked to see which nodes are <em>able</em> to
+            run the build and any workspaces found (aside from those in use) are
+            deleted.
+            <p>
+                Note: In situations where there have been more than one build of a
+                job running concurrently on a single node (i.e. the node has
+                multiple executors and the project has concurrent builds enabled)
+                then every build except the first will run on a non-default
+                workspace (e.g.
+                <code>.../workspace/ProjectName@2</code>
+                ). This method will <em>not</em> clean these non-default workspaces.
+            </p>
+            This method is best used where so little build history is kept (i.e.
+            projects have "Discard old builds" set to a small limit) that Jenkins
+            "has forgotten" some of the places where the build has run.
+        </dd>
+        <dt>Clean nodes that have been used</dt>
+        <dd>
+            The build history is scanned to see what nodes and workspaces were <em>actually</em>
+            used, and then all that are not currently in use are deleted.
+            <p>Note: This can be computationally expensive if projects have a
+                huge amount of build history to scan.</p>
+            This method is best used where enough build history is kept that
+            nodes will have their workspace wiped before that build is forgotten,
+            but not so much history is kept that it becomes a performance
+            problem.
+        </dd>
+        <dt>Clean nodes that could be, or have been, used</dt>
+        <dd>The union of both of the above.</dd>
+    </dl>
+    Note: In all cases, nodes that have the
+    <code>Skip this node when cleaning old build workspaces</code>
+    node property set will be skipped over, as will nodes whose name
+    matches a pattern in the
+    <code>Nodes to ignore</code>
+    field (below).
+</div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-parallel.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-parallel.html
@@ -1,0 +1,8 @@
+<div>
+    If set, clean-up happens on each node in parallel.
+    <br>
+    If not set, each node's clean-up is run to completion before the next is started.
+    <p>
+    Hint: Unless your nodes share the same underlying storage hardware and cannot cope with lots of deletion operations "all at once", it is suggested to have this flag set.
+    If it is unset and you have lots of nodes, your builds will be delayed due to the need to contact each node in sequence.
+</div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-skipRoaming.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-skipRoaming.html
@@ -1,0 +1,8 @@
+<div>
+    Dictates what to do if a job's label expression is empty (a
+    &quot;roaming&quot; project).
+    <p>
+        If we're inspecting what nodes <em>could</em> be used for a job <em>and</em>
+        that job has no restriction where it can run then, if this is set we
+        select no nodes, but if this is not set we select <em>all</em> nodes.
+</div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-timeoutInMilliseconds.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-timeoutInMilliseconds.html
@@ -1,0 +1,10 @@
+<div>
+    Sets a time limit in milliseconds for the clean-up to complete.
+    <p>
+    If set to a positive number and the clean-up operation takes longer than permitted, it will be aborted.  This will <em>not</em> cause the build to fail.
+    <br>
+    Otherwise the clean-up is allowed to run indefinitely.
+    <p>
+    Note: If a slave node locks up, it can cause all operations run on that node to also lock up, which includes the clean-up operation.
+    If you do not set a timeout then a single deadlocked node can cause all your builds to lock up until that slave is killed.
+</div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty/config.jelly
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty/config.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" />

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty/help.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty/help.html
@@ -1,0 +1,5 @@
+<div>
+    Ignore this node during the "Clean up workspaces from this job's old builds on other slave nodes" stage of a build.
+    By default, workspaces on all nodes are considered.
+    This property is typically used to mark one-shot or short-lived nodes where no long-term cleanup is required.
+</div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/Messages.properties
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/Messages.properties
@@ -1,1 +1,10 @@
-PrePostClean.displayName=Clean up all other workspaces of this job in the same slavegroup
+PrePostClean.displayName=Clean up this job's workspaces from other slave nodes.
+PrePostClean.warningNoTimeoutSet=If no timeout is set then a poorly slave node could cause this build to block indefinitely.
+DisablePrePostCleanNodeProperty.displayName=Skip this node when cleaning old build workspaces.
+NodeSelection.LABEL_ONLY.displayName=Clean nodes that could be used
+NodeSelection.HISTORY_ONLY.displayName=Clean nodes that have been used
+NodeSelection.LABEL_AND_HISTORY.displayName=Clean nodes that could be, or have been, used
+CommonConfig.skipRoamingIgnores=This field is ignored when only past workspaces are cleaned.
+CommonConfig.nodeNamesToSkip.whitespaceFirst=Regex#{0} has initial whitespace
+CommonConfig.nodeNamesToSkip.whitespaceLast=Regex#{0} has trailing whitespace
+CommonConfig.nodeNamesToSkip.invalid=Regex#{0} is not a valid regex: {1}

--- a/src/test/java/de/jamba/hudson/plugin/wsclean/CommonConfigTest.java
+++ b/src/test/java/de/jamba/hudson/plugin/wsclean/CommonConfigTest.java
@@ -1,0 +1,117 @@
+package de.jamba.hudson.plugin.wsclean;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import de.jamba.hudson.plugin.wsclean.CommonConfig.NodeSelection;
+import hudson.DescriptorExtensionList;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+import jenkins.model.TestJenkins;
+
+public class CommonConfigTest {
+
+    @Test
+    public void constructorGivenDefaultsThenReturnsDefaultInstance() throws Exception {
+        // Given
+        final String[] expectedNodeNamesToSkip = new String[0];
+        final Pattern[] expectedNodeNamesToSkipPatterns = new Pattern[0];
+        final String expectedNodeNamesToSkipString = "";
+        final NodeSelection expectedNodeSelection = NodeSelection.LABEL_ONLY;
+        final boolean expectedParallel = true;
+        final boolean expectedSkipRoaming = true;
+        final Long expectedTimeoutInMilliseconds = 900000L;
+
+        // When
+        final CommonConfig instance = new CommonConfig() {
+            @Override
+            public synchronized void load() {
+                // do nothing
+            }
+        };
+        final String[] actualNodeNamesToSkip = instance.getNodeNamesToSkip();
+        final Pattern[] actualNodeNamesToSkipPatterns = instance.getNodeNamesToSkipPatterns();
+        final String actualNodeNamesToSkipString = instance.getNodeNamesToSkipString();
+        final NodeSelection actualNodeSelection = instance.getNodeSelection();
+        final boolean actualParallel = instance.getParallel();
+        final boolean actualSkipRoaming = instance.getSkipRoaming();
+        final Long actualTimeoutInMilliseconds = instance.getTimeoutInMilliseconds();
+
+        // Then
+        assertThat(actualNodeNamesToSkip, equalTo(expectedNodeNamesToSkip));
+        assertThat(actualNodeNamesToSkipPatterns, equalTo(expectedNodeNamesToSkipPatterns));
+        assertThat(actualNodeNamesToSkipString, equalTo(expectedNodeNamesToSkipString));
+        assertThat(actualNodeSelection, equalTo(expectedNodeSelection));
+        assertThat(actualParallel, equalTo(expectedParallel));
+        assertThat(actualSkipRoaming, equalTo(expectedSkipRoaming));
+        assertThat(actualTimeoutInMilliseconds, equalTo(expectedTimeoutInMilliseconds));
+    }
+
+    @Test
+    public void setNodeNamesToSkipGivenNamesThenAlsoSetsPatterns() throws Exception {
+        // Given
+        final String expectedNodeNamesToSkipString = "foo\n(((invalidRegex\nbar";
+        final String[] expectedNodeNamesToSkip = new String[] { "foo", "(((invalidRegex", "bar" };
+        final Pattern[] expectedNodeNamesToSkipPatterns = new Pattern[] { Pattern.compile("foo"),
+                Pattern.compile("bar") };
+        final CommonConfig instance = new CommonConfig() {
+            @Override
+            public void load() {
+            }
+
+            @Override
+            public void save() {
+            }
+        };
+        // When
+        instance.setNodeNamesToSkipString(expectedNodeNamesToSkipString);
+
+        // Then
+        final String[] actualNodeNamesToSkip = instance.getNodeNamesToSkip();
+        final Pattern[] actualNodeNamesToSkipPatterns = instance.getNodeNamesToSkipPatterns();
+        final String actualNodeNamesToSkipString = instance.getNodeNamesToSkipString();
+
+        // Then
+        assertThat(actualNodeNamesToSkip, equalTo(expectedNodeNamesToSkip));
+        assertThat(actualNodeNamesToSkipString, equalTo(expectedNodeNamesToSkipString));
+        assertThat(actualNodeNamesToSkipPatterns.length, equalTo(expectedNodeNamesToSkipPatterns.length));
+        assertThat(actualNodeNamesToSkipPatterns[0].pattern(), equalTo(expectedNodeNamesToSkipPatterns[0].pattern()));
+        assertThat(actualNodeNamesToSkipPatterns[1].pattern(), equalTo(expectedNodeNamesToSkipPatterns[1].pattern()));
+    }
+
+    @SuppressWarnings("unchecked")
+    static void stubConfig(Jenkins mockJenkins, CommonConfig config) {
+        final DescriptorExtensionList<GlobalConfiguration, GlobalConfiguration> extensionList = mock(
+                DescriptorExtensionList.class);
+        when(extensionList.get(CommonConfig.class)).thenReturn(config);
+        when(mockJenkins.<GlobalConfiguration, GlobalConfiguration>getDescriptorList(GlobalConfiguration.class))
+                .thenReturn(extensionList);
+        TestJenkins.setJenkinsInstance(mockJenkins);
+    }
+
+    static void stubConfig(Jenkins mockJenkins, NodeSelection nodeSelection, boolean skipRoaming, boolean parallel,
+            String[] nodeNamesToSkip, long timeoutInMilliseconds) {
+        final CommonConfig instance = new CommonConfig() {
+            @Override
+            public void load() {
+            }
+
+            @Override
+            public void save() {
+            }
+        };
+        instance.setNodeSelection(nodeSelection);
+        instance.setSkipRoaming(skipRoaming);
+        instance.setParallel(parallel);
+        instance.setNodeNamesToSkip(nodeNamesToSkip);
+        instance.setTimeoutInMilliseconds(timeoutInMilliseconds);
+        stubConfig(mockJenkins, instance);
+    }
+
+}

--- a/src/test/java/de/jamba/hudson/plugin/wsclean/PrePostCleanTest.java
+++ b/src/test/java/de/jamba/hudson/plugin/wsclean/PrePostCleanTest.java
@@ -1,37 +1,65 @@
 package de.jamba.hudson.plugin.wsclean;
 
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
 
+import de.jamba.hudson.plugin.wsclean.CommonConfig.NodeSelection;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.Executor;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.TopLevelItem;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.BuildWrapper.Environment;
+import hudson.util.RunList;
 import jenkins.model.Jenkins;
+import jenkins.model.TestJenkins;
 
 @SuppressWarnings("rawtypes")
 public class PrePostCleanTest {
+
+    @AfterClass
+    public static void tearDownClass() {
+        TestJenkins.setJenkinsInstance(null);
+    }
+
     @Test
     public void constructorGivenDefaultsThenReturnsDefaultInstance() throws Exception {
         // Given
@@ -63,8 +91,6 @@ public class PrePostCleanTest {
     @Test
     public void setUpGivenBeforeIsFalseAndNotRoamingThenCleansOnlineMatchingNodesDuringTeardown() throws Exception {
         // Given
-        final TestPrePostClean instance = new TestPrePostClean();
-        instance.setBefore(false);
         final AbstractBuild mockBuild = mock(AbstractBuild.class, "mockBuild");
         final Launcher mockLauncher = mock(Launcher.class);
         final BuildListener mockListener = mock(BuildListener.class, "mockListener");
@@ -76,6 +102,7 @@ public class PrePostCleanTest {
         final String node2Name = "nodeA2";
         final String node3Name = "nodeA3";
         final String node4Name = "nodeA4-offline";
+        final Jenkins mockJenkins = mockNode(Jenkins.class, "mockJenkins", "", true);
         final Node mockNode1 = mockNode("mockNode1", node1Name, true);
         final Node mockNode2 = mockNode("mockNode2", node2Name, true);
         final Node mockNode3 = mockNode("mockNode3", node3Name, true);
@@ -93,6 +120,11 @@ public class PrePostCleanTest {
         when(mockBuild.getProject()).thenReturn(mockProject);
         when(mockProject.getAssignedLabel()).thenReturn(mockAssignedLabel);
         when(mockAssignedLabel.getNodes()).thenReturn(setOfMockNodes);
+        TestJenkins.setJenkinsInstance(mockJenkins);
+        whenJenkinsGetNode(mockJenkins, mockNode1, mockNode2, mockNode3, mockNode4);
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.setBefore(false);
+        CommonConfigTest.stubConfig(mockJenkins, NodeSelection.LABEL_ONLY, true, false, null, 0);
         final Environment env = instance.setUp(mockBuild, mockLauncher, mockListener);
         verifyNoMoreInteractions(mockBuild, mockLauncher, mockListener, instance.mock);
 
@@ -111,8 +143,6 @@ public class PrePostCleanTest {
     @Test
     public void setUpGivenBeforeIsTrueAndNotRoamingThenCleansOnlineMatchingNodesBeforeAndNotAfter() throws Exception {
         // Given
-        final TestPrePostClean instance = new TestPrePostClean();
-        instance.setBefore(true);
         final AbstractBuild mockBuild = mock(AbstractBuild.class, "mockBuild");
         final Launcher mockLauncher = mock(Launcher.class);
         final BuildListener mockListener = mock(BuildListener.class, "mockListener");
@@ -125,6 +155,7 @@ public class PrePostCleanTest {
         final String node3Name = "nodeA3";
         final String node4Name = "nodeA4-offline";
         final String node5Name = "nodeA5-offline";
+        final Jenkins mockJenkins = mockNode(Jenkins.class, "mockJenkins", "", true);
         final Node mockNode1 = mockNode("mockNode1", node1Name, true);
         final Node mockNode2 = mockNode("mockNode2", node2Name, true);
         final Node mockNode3 = mockNode("mockNode3", node3Name, true);
@@ -144,6 +175,11 @@ public class PrePostCleanTest {
         when(mockBuild.getProject()).thenReturn(mockProject);
         when(mockProject.getAssignedLabel()).thenReturn(mockAssignedLabel);
         when(mockAssignedLabel.getNodes()).thenReturn(setOfMockNodes);
+        TestJenkins.setJenkinsInstance(mockJenkins);
+        whenJenkinsGetNode(mockJenkins, mockNode1, mockNode2, mockNode3, mockNode4, mockNode5);
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.setBefore(true);
+        CommonConfigTest.stubConfig(mockJenkins, NodeSelection.LABEL_ONLY, true, false, null, 10000L);
 
         // When
         final Environment env = instance.setUp(mockBuild, mockLauncher, mockListener);
@@ -163,8 +199,6 @@ public class PrePostCleanTest {
     @Test
     public void setUpGivenBeforeIsTrueAndRoamingThenSkips() throws Exception {
         // Given
-        final TestPrePostClean instance = new TestPrePostClean();
-        instance.setBefore(true);
         final AbstractBuild mockBuild = mock(AbstractBuild.class, "mockBuild");
         final Launcher mockLauncher = mock(Launcher.class);
         final BuildListener mockListener = mock(BuildListener.class, "mockListener");
@@ -174,6 +208,10 @@ public class PrePostCleanTest {
         when(mockBuild.getBuiltOnStr()).thenReturn("someNode");
         when(mockBuild.getProject()).thenReturn(mockProject);
         when(mockProject.getAssignedLabel()).thenReturn(null); // roaming
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.setBefore(true);
+        final Jenkins mockJenkins = mockNode(Jenkins.class, "mockJenkins", "", true);
+        CommonConfigTest.stubConfig(mockJenkins, NodeSelection.LABEL_ONLY, true, false, null, 0L);
 
         // When
         final Environment env = instance.setUp(mockBuild, mockLauncher, mockListener);
@@ -182,6 +220,274 @@ public class PrePostCleanTest {
         verifyNoMoreInteractions(instance.mock);
         env.tearDown(mockBuild, mockListener);
         verifyNoMoreInteractions(instance.mock);
+    }
+
+    @Test
+    public void setUpGivenBuildHistoryOnlyAndBuildsThenDeletesOldWorkspaces() throws Exception {
+        // Given
+        final String normalWs = "/workspacesB/NormalPlace";
+        final String weirdWs = "/workspacesB/SomewhereElse";
+        final String masterName = "";
+        final String normalisedMasterName = "master";
+        final String node1Name = "nodeB1";
+        final String node2Name = "nodeB2";
+        final String node3Name = "nodeB3";
+        final String node4Name = "nodeB4";
+        final String node5Name = "nodeB5";
+        final Jenkins mockMaster = mockNode(Jenkins.class, "mockMaster", masterName, true);
+        final Node mockNode1 = mockNode("mockNode1", node1Name, true);
+        final Node mockNode2 = mockNode("mockNode2", node2Name, true);
+        final Node mockNode3 = mockNode("mockNode3", node3Name, true);
+        final Node mockNode4 = mockNode("mockNode4", node4Name, true);
+        final Node mockNode5 = mockNode("mockNode5", node5Name, true);
+        when(mockNode5.getNodeProperty(DisablePrePostCleanNodeProperty.class))
+                .thenReturn(new DisablePrePostCleanNodeProperty());
+        final Node mockNodeX = mockNode("mockNodeX", "nodeX", false);
+        whenJenkinsGetNode(mockMaster, mockNode1, mockNode2, mockNode3, mockNode4, mockNode5);
+
+        final AbstractBuild mockBuild1 = mockBuild("mockBuild1-completed-ranOnMaster", mockMaster, normalWs, false,
+                false);
+        final AbstractBuild mockBuild2 = mockBuild("mockBuild2-completed-ranOnNode1", mockNode1, normalWs, false,
+                false);
+        final AbstractBuild mockBuild3 = mockBuild("mockBuild3-completed-ranOnNode4", mockNode4, normalWs, false,
+                false);
+        final AbstractBuild mockBuild4 = mockBuild("mockBuild4-completed-ranOnNode3-inDifferentWS", mockNode3, weirdWs,
+                false, false);
+        final AbstractBuild mockBuild5 = mockBuild("mockBuild5-completed-ranOnNode3", mockNode3, normalWs, false,
+                false);
+        final AbstractBuild mockBuild6 = mockBuild("mockBuild6-completed-ranOnNode2", mockNode2, normalWs, false,
+                false);
+        final AbstractBuild mockBuild7 = mockBuild("mockBuild7-completed-ranOnUnknownNodeX", mockNodeX, normalWs, false,
+                false);
+        final AbstractBuild mockBuild8 = mockBuild("mockBuild8-completed-ranOnDisabledNode", mockNode5, normalWs, false,
+                false);
+        final AbstractBuild mockBuild9 = mockBuild("mockBuild9-ourCurrentBuild-runningOnNode1", mockNode1, normalWs,
+                false, true);
+        final AbstractBuild mockBuild10 = mockBuild("mockBuild10-concurrentWithUs-runningOnNode2", mockNode2, normalWs,
+                false, true);
+        final AbstractBuild mockBuild11 = mockBuild("mockBuild11-allocatedToSlaveButNotStartedYet", mockNode2, weirdWs,
+                true, false);
+        final AbstractBuild mockBuild12 = mockBuild("mockBuild12-notStartedYet", null, normalWs, true, false);
+        final List<AbstractBuild> listOfMockBuildHistory = ImmutableList.of(mockBuild12, mockBuild11, mockBuild10,
+                mockBuild9, mockBuild8, mockBuild7, mockBuild6, mockBuild5, mockBuild4, mockBuild3, mockBuild2,
+                mockBuild1);
+        final FilePath masterNormalWs = mockMaster.createPath(normalWs);
+        final FilePath node3NormalWs = mockNode3.createPath(normalWs);
+        final FilePath node3WeirdWs = mockNode3.createPath(weirdWs);
+        final FilePath node4NormalWs = mockNode4.createPath(normalWs);
+
+        final AbstractBuild mockCurrentBuild = mockBuild7;
+        final AbstractProject mockProject = mock(AbstractProject.class, withSettings().name("mockProject"));
+        when(mockCurrentBuild.getProject()).thenReturn(mockProject);
+        when(mockProject.getBuilds()).thenReturn(RunList.fromRuns(listOfMockBuildHistory));
+        final BuildListener mockListener = mock(BuildListener.class, "mockListener");
+        when(mockListener.getLogger()).thenReturn(System.out);
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.setBefore(true);
+        CommonConfigTest.stubConfig(mockMaster, NodeSelection.HISTORY_ONLY, true, false, null, 0L);
+        final Launcher mockLauncher = mock(Launcher.class);
+
+        // When
+        instance.setUp(mockCurrentBuild, mockLauncher, mockListener);
+
+        // Then
+        verify(instance.mock).deleteWorkspaceOn(mockListener, normalisedMasterName, masterNormalWs);
+        verify(instance.mock).deleteWorkspaceOn(mockListener, node3Name, node3NormalWs);
+        verify(instance.mock).deleteWorkspaceOn(mockListener, node3Name, node3WeirdWs);
+        verify(instance.mock).deleteWorkspaceOn(mockListener, node4Name, node4NormalWs);
+    }
+
+    @Test
+    public void deleteWssInSeriesGivenWorkspacesThenDeletesInOrder() throws InterruptedException, IOException {
+        // Given
+        final AbstractBuild mockCurrentBuild = mock(AbstractBuild.class, "mockCurrentBuild");
+        final String masterName = "";
+        final String normalizedMasterName = "master";
+        final String node1Name = "nodeC1";
+        final String node2Name = "nodeC2";
+        final String node3Name = "nodeC3WasDeletedUnderOurFeet";
+        final String ws1 = "/Cabc";
+        final String ws2 = "/Cdef";
+        final Node mockNode1 = mockNode("mockNode1", node1Name, true);
+        final Node mockNode2 = mockNode("mockNode2", node2Name, true);
+        final Jenkins mockJenkins = mockNode(Jenkins.class, "mockJenkins", "", true);
+        final FilePath masterws2 = mockJenkins.createPath(ws2);
+        final FilePath node1ws1 = mockNode1.createPath(ws1);
+        final FilePath node1ws2 = mockNode1.createPath(ws2);
+        final FilePath node2ws1 = mockNode2.createPath(ws1);
+        whenJenkinsGetNode(mockJenkins, mockNode1, mockNode2);
+        final BuildListener mockListener = mock(BuildListener.class, "mockListener");
+        when(mockListener.getLogger()).thenReturn(System.out);
+        final Multimap<String, String> workspacesToBeRemoved = TreeMultimap.create();
+        workspacesToBeRemoved.put(masterName, ws2);
+        workspacesToBeRemoved.put(node1Name, ws1);
+        workspacesToBeRemoved.put(node1Name, ws2);
+        workspacesToBeRemoved.put(node2Name, ws1);
+        workspacesToBeRemoved.put(node3Name, ws1);
+
+        // When
+        final TestPrePostClean instance = new TestPrePostClean();
+        instance.deleteWssInSeries(mockCurrentBuild, mockJenkins, workspacesToBeRemoved, mockListener);
+
+        // Then
+        final InOrder inOrder = inOrder(instance.mock);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, normalizedMasterName, masterws2);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node1Name, node1ws1);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node1Name, node1ws2);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node2Name, node2ws1);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void deleteWssInParallelGivenWorkspacesThenDeletesOnEachNodeInParallel()
+            throws InterruptedException, IOException {
+        // Given
+        final AbstractBuild mockCurrentBuild = mock(AbstractBuild.class, "mockCurrentBuild");
+        final String masterName = "";
+        final String normalizedMasterName = "master";
+        final String node1Name = "nodeD1";
+        final String node2Name = "nodeD2";
+        final String node3Name = "nodeD3WasDeletedUnderOurFeet";
+        final String node4Name = "nodeD4";
+        final String node5Name = "nodeD5";
+        final String ws1 = "/Dabc";
+        final String ws2 = "/Ddef";
+        final Jenkins mockJenkins = mockNode(Jenkins.class, "mockJenkins", "", true);
+        final Node mockNode1 = mockNode("mockNode1", node1Name, true);
+        final Node mockNode2 = mockNode("mockNode2", node2Name, true);
+        final Node mockNode4 = mockNode("mockNode4", node4Name, true);
+        final Node mockNode5 = mockNode("mockNode5", node5Name, true);
+        final FilePath masterws2 = mockJenkins.createPath(ws2);
+        final FilePath node1ws1 = mockNode1.createPath(ws1);
+        final FilePath node2ws1 = mockNode2.createPath(ws1);
+        final FilePath node2ws2 = mockNode2.createPath(ws2);
+        final FilePath node4ws1 = mockNode4.createPath(ws1);
+        final FilePath node5ws2 = mockNode5.createPath(ws2);
+        final TestPrePostClean instance = new TestPrePostClean();
+        final BuildListener mockListener = mock(BuildListener.class, "mockListener");
+        when(mockListener.getLogger()).thenReturn(System.out);
+        final long millisecondsRequiredToDeleteAWorkspace = 200L;
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Thread.sleep(millisecondsRequiredToDeleteAWorkspace);
+                return null;
+            }
+        }).when(instance.mock).deleteWorkspaceOn(any(), anyString(), any());
+        whenJenkinsGetNode(mockJenkins, mockNode1, mockNode2, mockNode4, mockNode5);
+        final Multimap<String, String> workspacesToBeRemoved = TreeMultimap.create();
+        workspacesToBeRemoved.put(masterName, ws2);
+        workspacesToBeRemoved.put(node1Name, ws1);
+        workspacesToBeRemoved.put(node2Name, ws1);
+        workspacesToBeRemoved.put(node2Name, ws2);
+        workspacesToBeRemoved.put(node3Name, ws1);
+        workspacesToBeRemoved.put(node4Name, ws1);
+        workspacesToBeRemoved.put(node5Name, ws2);
+
+        // When
+        final ExecutorService parallelExecutor = Executors.newFixedThreadPool(6);
+        final long timestampBeforeDeletion = System.currentTimeMillis();
+        instance.deleteWssInParallel(mockCurrentBuild, mockJenkins, parallelExecutor, workspacesToBeRemoved,
+                mockListener);
+        final long timestampAfterDeletion = System.currentTimeMillis();
+
+        // Then
+        verify(instance.mock).deleteWorkspaceOn(mockListener, normalizedMasterName, masterws2);
+        verify(instance.mock).deleteWorkspaceOn(mockListener, node1Name, node1ws1);
+        final InOrder inOrder = inOrder(instance.mock);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node2Name, node2ws1);
+        inOrder.verify(instance.mock).deleteWorkspaceOn(mockListener, node2Name, node2ws2);
+        verify(instance.mock).deleteWorkspaceOn(mockListener, node4Name, node4ws1);
+        verify(instance.mock).deleteWorkspaceOn(mockListener, node5Name, node5ws2);
+        verifyNoMoreInteractions(instance.mock);
+        final long timeTakenForDeletions = timestampAfterDeletion - timestampBeforeDeletion;
+        final long minTimeItCanTakeIsBothDeletionsOnNode2 = millisecondsRequiredToDeleteAWorkspace * 2;
+        final long maxExpectedTimeItShouldTakeIsNotMuchMore = minTimeItCanTakeIsBothDeletionsOnNode2
+                + millisecondsRequiredToDeleteAWorkspace / 2;
+        assertThat(timeTakenForDeletions, is(both(greaterThanOrEqualTo(minTimeItCanTakeIsBothDeletionsOnNode2))
+                .and(lessThan(maxExpectedTimeItShouldTakeIsNotMuchMore))));
+    }
+
+    @Test
+    public void deleteWssInParallelGivenInterruptThenAbandonsAllDeletionsImmediately()
+            throws InterruptedException, IOException {
+        // Given
+        final AbstractBuild mockCurrentBuild = mock(AbstractBuild.class, "mockCurrentBuild");
+        final String node1Name = "nodeE1";
+        final String node2Name = "nodeE2";
+        final String node3Name = "nodeE3";
+        final String ws = "/Eabc";
+        final Node mockNode1 = mockNode("mockNode1", node1Name, true);
+        final Node mockNode2 = mockNode("mockNode2", node2Name, true);
+        final Node mockNode3 = mockNode("mockNode3", node3Name, true);
+        final FilePath node1ws = mockNode1.createPath(ws);
+        final FilePath node2ws = mockNode2.createPath(ws);
+        final FilePath node3ws = mockNode3.createPath(ws);
+        final BuildListener mockListener = mock(BuildListener.class, "mockListener");
+        when(mockListener.getLogger()).thenReturn(System.out);
+        final TestPrePostClean instance = new TestPrePostClean();
+        final long timeEachDeletionWillRunForUnlessCancelled = 1000L;
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Thread.sleep(timeEachDeletionWillRunForUnlessCancelled);
+                return null;
+            }
+        }).when(instance.mock).deleteWorkspaceOn(mockListener, node1Name, node1ws);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Thread.sleep(timeEachDeletionWillRunForUnlessCancelled);
+                return null;
+            }
+        }).when(instance.mock).deleteWorkspaceOn(mockListener, node2Name, node2ws);
+        final Thread testThread = Thread.currentThread();
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                System.out.println("Interrupting main thread");
+                testThread.interrupt(); // interrupt the cleanup thread
+                Thread.sleep(timeEachDeletionWillRunForUnlessCancelled);
+                return null;
+            }
+        }).when(instance.mock).deleteWorkspaceOn(mockListener, node3Name, node3ws);
+        final Jenkins mockJenkins = mock(Jenkins.class, "mockJenkins");
+        whenJenkinsGetNode(mockJenkins, mockNode1, mockNode2, mockNode3);
+        final Multimap<String, String> workspacesToBeRemoved = TreeMultimap.create();
+        workspacesToBeRemoved.put(node1Name, ws);
+        workspacesToBeRemoved.put(node2Name, ws);
+        workspacesToBeRemoved.put(node3Name, ws);
+
+        // When
+        final ExecutorService parallelExecutor = Executors.newFixedThreadPool(6);
+        final long timestampBeforeDeletion = System.currentTimeMillis();
+        try {
+            instance.deleteWssInParallel(mockCurrentBuild, mockJenkins, parallelExecutor, workspacesToBeRemoved,
+                    mockListener);
+            fail("Expecting to be interrupted");
+        } catch (InterruptedException ex) {
+            // expected
+        }
+        final long timestampAfterDeletion = System.currentTimeMillis();
+
+        // Then
+        final long timeTakenForDeletions = timestampAfterDeletion - timestampBeforeDeletion;
+        assertThat(timeTakenForDeletions, lessThan(timeEachDeletionWillRunForUnlessCancelled));
+    }
+
+    private static AbstractBuild mockBuild(final String mockName, final Node builtOnNode, final String wsLocation,
+            final boolean hasntStartedYet, final boolean hasExecutor)
+            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        final String buildOnNodeName = builtOnNode == null ? "" : builtOnNode.getNodeName();
+        final AbstractBuild m = mock(AbstractBuild.class, mockName);
+        final Field wsField = AbstractBuild.class.getDeclaredField("workspace");
+        wsField.setAccessible(true);
+        wsField.set(m, wsLocation);
+        when(m.getBuiltOn()).thenReturn(builtOnNode);
+        when(m.getBuiltOnStr()).thenReturn(buildOnNodeName);
+        when(m.hasntStartedYet()).thenReturn(hasntStartedYet);
+        when(m.getExecutor()).thenReturn(hasExecutor ? mock(Executor.class, mockName + "_executor") : null);
+        return m;
     }
 
     private static Node mockNode(final String mockName, final String nodeName, boolean nodeIsOnline) {
@@ -207,6 +513,15 @@ public class PrePostCleanTest {
         return m;
     }
 
+    private static void whenJenkinsGetNode(final Jenkins mockJenkins, Node... nodes) {
+        for (final Node n : nodes) {
+            final String nodeName = n.getNodeName();
+            assert nodeName != null && !nodeName.isEmpty();
+            when(mockJenkins.getNode(nodeName)).thenReturn(n);
+        }
+        when(mockJenkins.getNodes()).thenReturn(Arrays.asList(nodes));
+    }
+
     private interface IMockableMethods {
         void deleteWorkspaceOn(BuildListener listener, String nodeName, FilePath fp) throws InterruptedException;
     }
@@ -215,7 +530,8 @@ public class PrePostCleanTest {
         final IMockableMethods mock = mock(IMockableMethods.class);
 
         @Override
-        void deleteWorkspaceOn(BuildListener listener, String nodeName, FilePath fp) throws InterruptedException {
+        void deleteWorkspaceOn(AbstractBuild<?, ?> build, BuildListener listener, String nodeName, FilePath fp)
+                throws InterruptedException {
             mock.deleteWorkspaceOn(listener, nodeName, fp);
         }
     }

--- a/src/test/java/de/jamba/hudson/plugin/wsclean/TaskUtilsTest.java
+++ b/src/test/java/de/jamba/hudson/plugin/wsclean/TaskUtilsTest.java
@@ -1,0 +1,248 @@
+package de.jamba.hudson.plugin.wsclean;
+
+import static de.jamba.hudson.plugin.wsclean.TaskUtils.runWithTimeout;
+import static de.jamba.hudson.plugin.wsclean.TaskUtils.runWithoutTimeout;
+import static de.jamba.hudson.plugin.wsclean.TaskUtils.waitUntilAllAreDone;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class TaskUtilsTest {
+    @Test
+    public void runWithoutTimeoutGivenTaskThatReturnsThenResultsResult() throws Exception {
+        // Given
+        final Integer expected = 123;
+        final Callable<Integer> task = mkTaskThatReturns(expected);
+        // When
+        final Integer actual = runWithoutTimeout(task);
+        // Then
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void runWithoutTimeoutGivenTaskThatThrowsRTEThenThrowsThatRTE() throws Exception {
+        // Given
+        final RuntimeException expected = new RuntimeException("expected");
+        final Callable<Integer> task = mkTaskThatThrows(expected);
+        // When
+        try {
+            runWithoutTimeout(task);
+            fail("Expected " + expected);
+        } catch (RuntimeException actual) {
+            // Then
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @Test
+    public void runWithoutTimeoutGivenTaskThatsInterruptedThenThrowsIE() throws Exception {
+        // Given
+        final InterruptedException expected = new InterruptedException("expected");
+        final Callable<Integer> task = mkTaskThatThrows(expected);
+        // When
+        try {
+            runWithoutTimeout(task);
+            fail("Expected " + expected);
+        } catch (InterruptedException actual) {
+            // Then
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @Test
+    public void runWithoutTimeoutGivenTaskThatThrowsAnythingElseThenWrapsIt() throws Exception {
+        // Given
+        final Exception expected = new Exception("expected-to-be-wrapped");
+        final Callable<Integer> task = mkTaskThatThrows(expected);
+        // When
+        try {
+            runWithoutTimeout(task);
+            fail("Expected " + expected);
+        } catch (RuntimeException ex) {
+            // Then
+            final Throwable actual = ex.getCause();
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @Test
+    public void runWithTimeoutGivenTaskThatReturnsThenResultsResultImmediately() throws Exception {
+        // Given
+        final ExecutorService threadpool = Executors.newSingleThreadExecutor();
+        final long timeoutInMs = 60000L;
+        final long maxExpectedExecutionDurationInMs = 100L;
+        final Integer expected = 123;
+        final Callable<Integer> task = mkTaskThatReturns(expected);
+        // When
+        final long msBeforeRun = System.currentTimeMillis();
+        final Integer actual = runWithTimeout(threadpool, timeoutInMs, task);
+        final long msAfterRun = System.currentTimeMillis();
+        // Then
+        assertThat(actual, equalTo(expected));
+        final long actualDuration = msAfterRun - msBeforeRun;
+        assertThat(actualDuration, lessThan(maxExpectedExecutionDurationInMs));
+    }
+
+    @Test
+    public void runWithTimeoutGivenTaskThatTakesTooLongToReturnThenThrowsTimeout() throws Exception {
+        // Given
+        final ExecutorService threadpool = Executors.newSingleThreadExecutor();
+        final long timeoutInMs = 50L;
+        final long maxExpectedExecutionDurationInMs = timeoutInMs + 100L;
+        final Callable<Integer> task = mkTaskThatReturnsAfterDelay(123, timeoutInMs + 1000L);
+        // When
+        final long msBeforeRun = System.currentTimeMillis();
+        try {
+            runWithTimeout(threadpool, timeoutInMs, task);
+            fail("Expecting timeout");
+        } catch (TimeoutException expected) {
+            // expected
+        }
+        final long msAfterRun = System.currentTimeMillis();
+        // Then
+        final long actualDuration = msAfterRun - msBeforeRun;
+        assertThat(actualDuration, lessThan(maxExpectedExecutionDurationInMs));
+        final boolean thisThreadWasInterrupted = Thread.currentThread().isInterrupted();
+        assertThat(thisThreadWasInterrupted, is(false));
+    }
+
+    @Test
+    public void runWithTimeoutGivenTaskThatThrowsRTEThenThrowsThatRTE() throws Exception {
+        // Given
+        final ExecutorService threadpool = Executors.newSingleThreadExecutor();
+        final long timeoutInMs = 60000L;
+        final RuntimeException expected = new RuntimeException("expected");
+        final Callable<Integer> task = mkTaskThatThrows(expected);
+        // When
+        try {
+            runWithTimeout(threadpool, timeoutInMs, task);
+            fail("Expected " + expected);
+        } catch (RuntimeException actual) {
+            // Then
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @Test
+    public void runWithTimeoutGivenTaskThatsInterruptedThenThrowsIE() throws Exception {
+        // Given
+        final ExecutorService threadpool = Executors.newSingleThreadExecutor();
+        final long timeoutInMs = 60000L;
+        final InterruptedException expected = new InterruptedException("expected");
+        final Callable<Integer> task = mkTaskThatThrows(expected);
+        // When
+        try {
+            runWithTimeout(threadpool, timeoutInMs, task);
+            fail("Expected " + expected);
+        } catch (InterruptedException actual) {
+            // Then
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @Test
+    public void runWithTimeoutGivenTaskThatThrowsAnythingElseThenWrapsIt() throws Exception {
+        // Given
+        final ExecutorService threadpool = Executors.newSingleThreadExecutor();
+        final long timeoutInMs = 60000L;
+        final Exception expected = new Exception("expected-to-be-wrapped");
+        final Callable<Integer> task = mkTaskThatThrows(expected);
+        // When
+        try {
+            runWithTimeout(threadpool, timeoutInMs, task);
+            fail("Expected " + expected);
+        } catch (RuntimeException ex) {
+            // Then
+            final Throwable actual = ex.getCause();
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @Test
+    public void waitUntilAllAreDoneGivenNothingThenReturnsImmediately() throws Exception {
+        // Given
+        final long maxExpectedExecutionDurationInMs = 100L;
+        final Iterable<Future<?>> tasks = Collections.emptyList();
+        // When
+        final long msBeforeRun = System.currentTimeMillis();
+        waitUntilAllAreDone(tasks);
+        final long msAfterRun = System.currentTimeMillis();
+        // Then
+        final long actualDuration = msAfterRun - msBeforeRun;
+        assertThat(actualDuration, lessThan(maxExpectedExecutionDurationInMs));
+    }
+
+    @Test
+    public void waitUntilAllAreDoneGivenWorkingTasksThenReturnsImmediatelyAfterLastCompletes() throws Exception {
+        // Given
+        final ExecutorService threadpool = Executors.newFixedThreadPool(4);
+        final long minExpectedExecutionDurationInMs = 105L;
+        final long maxExpectedExecutionDurationInMs = minExpectedExecutionDurationInMs + 100L;
+        final Callable<Integer> task10 = mkTaskThatThrows(new Exception("should-be-swallowed"));
+        final Callable<Integer> task30 = mkTaskThatReturnsAfterDelay(123, 50L);
+        final Callable<Integer> task50 = mkTaskThatReturnsAfterDelay(123, 40L);
+        final Callable<Integer> task70 = mkTaskThatReturnsAfterDelay(123, minExpectedExecutionDurationInMs);
+        final List<Future<?>> tasks = Lists.newArrayList();
+        tasks.add(threadpool.submit(task10));
+        tasks.add(threadpool.submit(task30));
+        tasks.add(threadpool.submit(task50));
+        final long msBeforeRun = System.currentTimeMillis();
+        tasks.add(threadpool.submit(task70));
+        // When
+        waitUntilAllAreDone(tasks);
+        final long msAfterRun = System.currentTimeMillis();
+        // Then
+        final long actualDuration = msAfterRun - msBeforeRun;
+        assertThat(actualDuration, lessThan(maxExpectedExecutionDurationInMs));
+        assertThat(actualDuration, greaterThanOrEqualTo(minExpectedExecutionDurationInMs));
+    }
+
+    private static <T> Callable<T> mkTaskThatReturns(final T returnValue) {
+        return new Callable<T>() {
+            @Override
+            public T call() throws Exception {
+                return returnValue;
+            }
+        };
+    }
+
+    private static <T> Callable<T> mkTaskThatReturnsAfterDelay(final T returnValue, final long delayInMs) {
+        return new Callable<T>() {
+            @Override
+            public T call() throws Exception {
+                final long tsBefore = System.currentTimeMillis();
+                while (true) {
+                    final long tsNow = System.currentTimeMillis();
+                    final long delaySoFar = tsNow - tsBefore;
+                    final long delayRemaining = delayInMs - delaySoFar;
+                    if (delayRemaining <= 0L) {
+                        break;
+                    }
+                    Thread.sleep(delayRemaining);
+                }
+                return returnValue;
+            }
+        };
+    }
+
+    private static <T> Callable<T> mkTaskThatThrows(final Exception thrown) {
+        return new Callable<T>() {
+            @Override
+            public T call() throws Exception {
+                throw thrown;
+            }
+        };
+    }
+}

--- a/src/test/java/jenkins/model/TestJenkins.java
+++ b/src/test/java/jenkins/model/TestJenkins.java
@@ -1,0 +1,37 @@
+package jenkins.model;
+
+import javax.annotation.CheckForNull;
+
+public class TestJenkins {
+    private static Jenkins.JenkinsHolder originalHolder;
+
+    /**
+     * Sets the value that {@link Jenkins#getInstance()} will return during a test.
+     * 
+     * @param mockJenkinsOrNull Null to restore the original value, otherwise
+     *                          (typically) a mock {@link Jenkins} instance.
+     */
+    public static void setJenkinsInstance(Jenkins mockJenkinsOrNull) {
+        Jenkins.JenkinsHolder current = Jenkins.HOLDER;
+        if (!(current == null || current instanceof OurJenkinsHolder)) {
+            originalHolder = current;
+        }
+        if (mockJenkinsOrNull == null) {
+            Jenkins.HOLDER = originalHolder;
+        } else {
+            Jenkins.HOLDER = new OurJenkinsHolder(mockJenkinsOrNull);
+        }
+    }
+
+    private static class OurJenkinsHolder implements Jenkins.JenkinsHolder {
+        private final Jenkins theInstance;
+
+        public OurJenkinsHolder(Jenkins theInstance) {
+            this.theInstance = theInstance;
+        }
+
+        public @CheckForNull Jenkins getInstance() {
+            return theInstance;
+        }
+    };
+}


### PR DESCRIPTION
Multiple enhancements that, combined, ensure that the plugin copes well when there's multiple concurrent builds, or lots of slave nodes, including cloud-provisioned nodes that need no cleanup, and we now even cope when some nodes have locked up.

* [JENKINS-58493](https://issues.jenkins-ci.org/browse/JENKINS-58493): Added DisablePrePostCleanNodeProperty so we can exclude certain nodes from cleanup.
* [JENKINS-58492](https://issues.jenkins-ci.org/browse/JENKINS-58492) part 1/2: Can now delete on every node at once, running deletions in parallel.
* [JENKINS-58492](https://issues.jenkins-ci.org/browse/JENKINS-58492) part 2/2: Deletion timeout prevents cleanup from blocking builds indefinitely.
* [JENKINS-43269](https://issues.jenkins-ci.org/browse/JENKINS-43269): Now takes _all_ currently running builds into account, including concurrent ones.
