### PR TITLE
Legal stuff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,43 @@
 # General
 
-- Please do not use the issue tracker to ask questions, join jenkins-users mailing list.
+- Please do not use the issue tracker to ask questions.
 This facility is for reporting (and fixing) bugs in the code.
 If you're not 100% sure it's a bug in the code then please seek help elsewhere.
-- [RTFM](https://en.wikipedia.org/wiki/RTFM). The Jenkins UI pages include help that explain a lot of things. The [the plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Distributed+Workspace+Clean+plugin) explains more.
+e.g. the [jenkins-users google group](https://groups.google.com/forum/#!forum/jenkinsci-users).
+- [RTFM](https://en.wikipedia.org/wiki/RTFM).
+The Jenkins UI pages include help that should explain things.
+The [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Distributed+Workspace+Clean+plugin) gives additional information.
 - Be helpful and make no demands.
   * This code is Free Open-Source Software - nobody is obliged to make things work for you *but* you have legal permission to fix things yourself.
   * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.
   * If you're relying on someone else to fix a problem then you should to make it as easy as possible for others to fix it for you, and you should test any fixes provided.
 
-# Creating new issue
+# Legal conditions
+
+- Any contributions (code, information etc) submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
+- As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+
+# Reporting a new issue
 
 - Provide a full description of the issue you are facing.
   * What are you trying to do?
   * How is this failing?
   * What should happen instead?
 - Provide step-by-step instructions for how to reproduce the issue.
-- Specify the Jenkins core version you're seeing the issue with, along with a full list of installed plugins with versions.
+- Specify the Jenkins core & plugin version you're seeing the issue with.
 - Check `Manage Jenkins` -> `Manage Old Data` for out of date configuration data and provide this info.
-- Check and provide errors from system jenkins.log and errors from `Manage Jenkins` -> `System Log`.
-  * If that log is too verbose, create a `wsclean-plugin` log that only logs `de.jamba.hudson.plugin.wsclean` (e.g. at level "ALL") and grab what's logged when you reproduce the issue.
+- Check and provide errors from the build log(s) and any errors from `Manage Jenkins` -> `System Log`.
+  * If the System Log is too verbose, create a `wsclean-plugin` log that only logs `de.jamba.hudson.plugin.wsclean` (e.g. at level "ALL") and grab what's logged when you reproduce the issue.
   * If _that_ log is too verbose, drop the level from "ALL" to a less verbose setting (at full verbosity, this plugin logs a lot), taking care to ensure that you're not removing anything relevant.
   * Exceptions and stacktraces are *especially* useful, so don't omit those...
   * Note that sensitive information may be visible in logs, so take care to redact logs where necessary.
 - Ensure that any code or log example surround with right markdown https://help.github.com/articles/github-flavored-markdown/ otherwise it'll be unreadable.
 
-# For pull requests
+# Submitting pull requests
 
-- Legal notice:
-  * Any code submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
-  * As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
 - A PR's description must EITHER refer to an existing issue (either in github or on Jenkins JIRA) OR include a full description as for "Creating new issue".
 - A single PR should EITHER be making functional changes OR making (non-functional) cosmetic/refactoring changes to the code.
-Please do not do both in the same PR or it makes life difficult for anyone else merging your changes.
+Please do not do both in the same PR as this makes life difficult for anyone else merging your changes.
 - For functional-change PRs, keep changes to a minimum (to make merges easier).
 - Coding style:
   * Try to fit in.
@@ -45,12 +50,11 @@ Please do not do both in the same PR or it makes life difficult for anyone else 
   * Any new functionality must be unit tested.
   * PRs that add unit-tests for existing functionality will be very welcome too.
   * Unit tests should be as fast as possible but *must* be reliable (Tests that behave inconsistently cause trouble for everyone else trying to work on the code).
-- Clean builds:
+- Clean build & test:
   * Any submitted PRs should automatically get built and tested; PRs will not be considered for merger until they are showing a clean build.
   If you believe that the build failed for reasons unconnected to your changes, close your PR, wait 10 minutes, then re-open it (just re-open the same PR; don't create a new one) to trigger a rebuild.
   Repeat until it builds clean, changing your code if necessary.
-  * Don't give findbugs anything new to complain about.
-  * Don't give the compiler/IDEs anything new to warn about.
+  * Don't give findbugs, the compiler or any IDEs anything new to complain about.
 - Preserve existing functionality by default:
   * Where possible, ensure that existing users don't find that their functionality has changed after they've upgraded from an old version of the plugin to a version of the plugin that contains your changes.
   * When adding new functionality, try to keep the defaults are unchanged so that nobody finds new, unexpected, things happening after upgrading.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# General
+
+- Please do not use the issue tracker to ask questions, join jenkins-users mailing list.
+This facility is for reporting (and fixing) bugs in the code.
+If you're not 100% sure it's a bug in the code then please seek help elsewhere.
+- [RTFM](https://en.wikipedia.org/wiki/RTFM). The Jenkins UI pages include help that explain a lot of things. The [the plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Distributed+Workspace+Clean+plugin) explains more.
+- Be helpful and make no demands.
+  * This code is Free Open-Source Software - nobody is obliged to make things work for you *but* you have legal permission to fix things yourself.
+  * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.
+  * If you're relying on someone else to fix a problem then you should to make it as easy as possible for others to fix it for you, and you should test any fixes provided.
+
+# Creating new issue
+
+- Provide a full description of the issue you are facing.
+  * What are you trying to do?
+  * How is this failing?
+  * What should happen instead?
+- Provide step-by-step instructions for how to reproduce the issue.
+- Specify the Jenkins core version you're seeing the issue with, along with a full list of installed plugins with versions.
+- Check `Manage Jenkins` -> `Manage Old Data` for out of date configuration data and provide this info.
+- Check and provide errors from system jenkins.log and errors from `Manage Jenkins` -> `System Log`.
+  * If that log is too verbose, create a `wsclean-plugin` log that only logs `de.jamba.hudson.plugin.wsclean` (e.g. at level "ALL") and grab what's logged when you reproduce the issue.
+  * If _that_ log is too verbose, drop the level from "ALL" to a less verbose setting (at full verbosity, this plugin logs a lot), taking care to ensure that you're not removing anything relevant.
+  * Exceptions and stacktraces are *especially* useful, so don't omit those...
+  * Note that sensitive information may be visible in logs, so take care to redact logs where necessary.
+- Ensure that any code or log example surround with right markdown https://help.github.com/articles/github-flavored-markdown/ otherwise it'll be unreadable.
+
+# For pull requests
+
+- Legal notice:
+  * Any code submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
+  * As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+- A PR's description must EITHER refer to an existing issue (either in github or on Jenkins JIRA) OR include a full description as for "Creating new issue".
+- A single PR should EITHER be making functional changes OR making (non-functional) cosmetic/refactoring changes to the code.
+Please do not do both in the same PR or it makes life difficult for anyone else merging your changes.
+- For functional-change PRs, keep changes to a minimum (to make merges easier).
+- Coding style:
+  * Try to fit in.
+  Not all of the code within this plugin is written in the same "style".
+  Any changes you make must fit in with the existing style that is prevalent within the area in which you are working.
+  i.e. code in the same style that the existing method/class/package uses.
+  * If you can't tolerate inconsistencies, submit a cosmetic PR that applies the formatting/whitespace/non-functional changes that you want made.
+  * If in doubt, use 4 spaces for indentation, avoid using tabs, avoid trailing whitespace, use unix end-of-line codes (LF, not CR/LF), and make sure every file ends with a newline.
+- Unit tests:
+  * Any new functionality must be unit tested.
+  * PRs that add unit-tests for existing functionality will be very welcome too.
+  * Unit tests should be as fast as possible but *must* be reliable (Tests that behave inconsistently cause trouble for everyone else trying to work on the code).
+- Clean builds:
+  * Any submitted PRs should automatically get built and tested; PRs will not be considered for merger until they are showing a clean build.
+  If you believe that the build failed for reasons unconnected to your changes, close your PR, wait 10 minutes, then re-open it (just re-open the same PR; don't create a new one) to trigger a rebuild.
+  Repeat until it builds clean, changing your code if necessary.
+  * Don't give findbugs anything new to complain about.
+  * Don't give the compiler/IDEs anything new to warn about.
+- Preserve existing functionality by default:
+  * Where possible, ensure that existing users don't find that their functionality has changed after they've upgraded from an old version of the plugin to a version of the plugin that contains your changes.
+  * When adding new functionality, try to keep the defaults are unchanged so that nobody finds new, unexpected, things happening after upgrading.
+  * Ensure any breaking changes are well documented in the PR description.
+- Configuration data changes:
+  * If the PR adds a new field to an existing (or new) data structure, make sure you've written good help text for it that explains what it's for, why it's useful, and an example.
+  Implement corresponding `doCheck` methods to provide validation when users are entering this data from the WebUI.
+  * If the PR changes an existing field, make sure that the code copes with reading in data from older versions of the plugin.
+
+# Links
+
+- https://wiki.jenkins.io/display/JENKINS/Distributed+Workspace+Clean+plugin
+- https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing
+- https://wiki.jenkins.io/display/JENKINS/Extend+Jenkins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,9 @@ The [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Distributed+Wor
 
 # Legal conditions
 
-- Any contributions (code, information etc) submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
-- As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+- Any contributions (code, information etc) submitted will be subject to the same [license](LICENSE) as the rest of the code.
+No new restrictions/conditions are permitted.
+- As a contributor, you MUST have the legal right to grant permission for your contribution to be used under these conditions.
 
 # Reporting a new issue
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2009, multiple contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>hpi</packaging>
     <name>Distributed Workspace Clean plugin</name>
     <version>1.0.7-SNAPSHOT</version>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Distributed+Workspace+Clean+plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Distributed+Workspace+Clean+plugin</url>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -15,15 +15,21 @@
     </parent>
 
     <description>This plugin cleans all old workspace directories used by the job</description>
-    <organization>
-        <name>Fox Mobile Distribution GmbH</name>
-        <url>http://www.jamba.de</url>
-    </organization>
+
+    <licenses>
+        <license>
+            <name>The MIT license</name>
+            <url>https://www.opensource.org/licenses/mit</url>
+            <distribution>repo</distribution>
+        </license>
+     </licenses>
+
     <developers>
-        <!-- Original author was Thomas Spengler, aka tspengler.  No longer involved. -->
-        <!-- Subsequently maintained by Arnaud Héritier, aka aheritier.  No longer involved. -->
+        <!-- Original (in 2009) author was Thomas Spengler, aka tspengler.  No longer involved. -->
+        <!-- Subsequently (2010) maintained by Alan Harder, aka alanharder.  No longer involved. -->
+        <!-- Subsequently (2015-2016) maintained by Arnaud Héritier, aka aheritier.  No longer involved. -->
         <developer>
-            <!-- Currently maintained by / last touched by -->
+            <!-- Currently (2018) maintained by / last touched by -->
             <id>pjdarton</id>
             <name>Peter Darton</name>
         </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -18,20 +18,40 @@
 
     <licenses>
         <license>
-            <name>The MIT license</name>
-            <url>https://www.opensource.org/licenses/mit</url>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
             <distribution>repo</distribution>
         </license>
      </licenses>
 
     <developers>
-        <!-- Original (in 2009) author was Thomas Spengler, aka tspengler.  No longer involved. -->
-        <!-- Subsequently (2010) maintained by Alan Harder, aka alanharder.  No longer involved. -->
-        <!-- Subsequently (2015-2016) maintained by Arnaud Héritier, aka aheritier.  No longer involved. -->
         <developer>
-            <!-- Currently (2018) maintained by / last touched by -->
+            <id>tspengler</id>
+            <name>Thomas Spengler</name>
+            <roles>
+                <role>maintainer (retired)</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>alanharder</id>
+            <name>Alan Harder</name>
+            <roles>
+                <role>maintainer (retired)</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>aheritier</id>
+            <name>Arnaud Héritier</name>
+            <roles>
+                <role>maintainer (retired)</role>
+            </roles>
+        </developer>
+        <developer>
             <id>pjdarton</id>
             <name>Peter Darton</name>
+            <roles>
+                <role>maintainer</role>
+            </roles>
         </developer>
     </developers>
 

--- a/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
@@ -42,7 +42,6 @@ import hudson.model.TopLevelItem;
 import hudson.remoting.RequestAbortedException;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
-import hudson.util.FormValidation;
 import hudson.util.RunList;
 import jenkins.model.Jenkins;
 


### PR DESCRIPTION
We didn't have any contribution guidelines to mention the requirement that ALL contributions have to be released under the same license as the rest of the plugin (which would be the Jenkins default license, MIT, in this case).
My friendly corporate lawyer suggested that it'd be a good idea to make this clear.

I've also added a ton of other "if you're writing a PR, please ensure..." stuff in the hope that folks might do that.

See also similar PRs, as any comments/changes there may be relevant here:
1. https://github.com/jenkinsci/docker-plugin/pull/749
1. https://github.com/jenkinsci/extra-tool-installers-plugin/pull/17
1. https://github.com/jenkinsci/vsphere-cloud-plugin/pull/109