### PR TITLE
Update terminology of 'slave' to 'agent'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ _August 28th, 2019:_
 Don't clean concurrently-running builds
 ([JENKINS-43269](https://issues.jenkins-ci.org/browse/JENKINS-43269))
 * :heavy_check_mark:
-Implement timeouts so dud slave nodes don't block all builds
+Implement timeouts so dud agent nodes don't block all builds
 * :heavy_check_mark:
 Implement "parallel cleanup" to improve performance
 * :heavy_check_mark:
@@ -28,7 +28,7 @@ Fix Compatibility with Folder plugin
 * :x:
 Fix deletion on master
 * :x:
-Don't wait for slave to become online/don't try to reconnect slave, if slave is offline
+Don't wait for agent to become online/don't try to reconnect agent, if agent is offline
 * :heavy_check_mark:
 Various cleanup/refactoring
 * :heavy_check_mark:
@@ -51,7 +51,7 @@ Fix broken classinformation due to change of from interface to abstract class.
 Fix
 [JENKINS-4630](https://issues.jenkins-ci.org/browse/JENKINS-4630)
 * :x:
-NPE while running PrePostClean without any slaves
+NPE while running PrePostClean without any agents
 
 ### Version 1.0.2
 * :x:

--- a/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/PrePostClean.java
@@ -256,7 +256,7 @@ public class PrePostClean extends BuildWrapper {
     }
 
     /**
-     * Uses the job label expression to determine what slave nodes this build could
+     * Uses the job label expression to determine what agent nodes this build could
      * run on and, from that, guess what workspaces we should delete. Note: This
      * does not take concurrent builds into account.
      * 
@@ -302,7 +302,7 @@ public class PrePostClean extends BuildWrapper {
     }
 
     /**
-     * Uses the old build history to determine what workspaces (on what slave nodes)
+     * Uses the old build history to determine what workspaces (on what agent nodes)
      * we should delete.
      * 
      * @param wssCurrentlyInUse    Where to record workspaces that are currently in
@@ -400,8 +400,8 @@ public class PrePostClean extends BuildWrapper {
     }
 
     /**
-     * Deletes workspaces, using a separate thread for each slave node affected so
-     * that all the slave nodes do their deletions in parallel.
+     * Deletes workspaces, using a separate thread for each agent node affected so
+     * that all the agent nodes do their deletions in parallel.
      * 
      * @param build                 The build this is for. This is only used for
      *                              diagnostic logging.

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-timeoutInMilliseconds.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/CommonConfig/help-timeoutInMilliseconds.html
@@ -5,6 +5,6 @@
     <br>
     Otherwise the clean-up is allowed to run indefinitely.
     <p>
-    Note: If a slave node locks up, it can cause all operations run on that node to also lock up, which includes the clean-up operation.
-    If you do not set a timeout then a single deadlocked node can cause all your builds to lock up until that slave is killed.
+    Note: If a agent node locks up, it can cause all operations run on that node to also lock up, which includes the clean-up operation.
+    If you do not set a timeout then a single deadlocked node can cause all your builds to lock up until that agent is killed.
 </div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty/help.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty/help.html
@@ -1,5 +1,5 @@
 <div>
-    Ignore this node during the "Clean up workspaces from this job's old builds on other slave nodes" stage of a build.
+    Ignore this node during the "Clean up workspaces from this job's old builds on other agent nodes" stage of a build.
     By default, workspaces on all nodes are considered.
     This property is typically used to mark one-shot or short-lived nodes where no long-term cleanup is required.
 </div>

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/Messages.properties
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/Messages.properties
@@ -1,5 +1,5 @@
-PrePostClean.displayName=Clean up this job's workspaces from other slave nodes.
-PrePostClean.warningNoTimeoutSet=If no timeout is set then a poorly slave node could cause this build to block indefinitely.
+PrePostClean.displayName=Clean up this job's workspaces from other agent nodes.
+PrePostClean.warningNoTimeoutSet=If no timeout is set then a poorly agent node could cause this build to block indefinitely.
 DisablePrePostCleanNodeProperty.displayName=Skip this node when cleaning old build workspaces.
 NodeSelection.LABEL_ONLY.displayName=Clean nodes that could be used
 NodeSelection.HISTORY_ONLY.displayName=Clean nodes that have been used

--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help.html
@@ -1,14 +1,14 @@
 <div>
-    Cleans up workspaces from this job's old builds on other slave nodes.
+    Cleans up workspaces from this job's old builds on other agent nodes.
     <p>
-    By default, a slave node will leave a build's workspace on the slave node's filesystem
+    By default, a agent node will leave a build's workspace on the agent node's filesystem
     indefinitely (until it gets overwritten by a new build).
-    When there's a (large) pool of persistent slave nodes available to run a (large) number of builds,
-    eventually every slave node ends up with a copy of every builds' workspace.
+    When there's a (large) pool of persistent agent nodes available to run a (large) number of builds,
+    eventually every agent node ends up with a copy of every builds' workspace.
     This is a waste of hardware resources as Jenkins will only look at the workspace on the most
-    recently used slave node.
+    recently used agent node.
     <br>
-    This functionality triggers a clean up of the workspace on all slave nodes
-    that are not currently being used so that, on average, the pool of slaves will only
+    This functionality triggers a clean up of the workspace on all agent nodes
+    that are not currently being used so that, on average, the pool of agents will only
     contain one workspace for each job.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Allows cleanup of old job workspaces on slaves used by old builds.
+    Allows cleanup of old job workspaces on agents used by old builds.
 </div>


### PR DESCRIPTION
Jenkins was designed with a "master <-> slave" architecture. 'slave' is deprecated and 'agent' should be used instead.
#words-matter
https://www.ibm.com/blogs/think/2020/08/words-matter-driving-thoughtful-change-toward-inclusive-language-in-technology/