### PR TITLE
Modified help.html file with editing the word slave to agent

### DIFF
--- a/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help.html
+++ b/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean/help.html
@@ -1,14 +1,14 @@
 <div>
-    Cleans up workspaces from this job's old builds on other slave nodes.
+    Cleans up workspaces from this job's old builds on other agent nodes.
     <p>
-    By default, a slave node will leave a build's workspace on the slave node's filesystem
+    By default, a agent node will leave a build's workspace on the agent node's filesystem
     indefinitely (until it gets overwritten by a new build).
-    When there's a (large) pool of persistent slave nodes available to run a (large) number of builds,
-    eventually every slave node ends up with a copy of every builds' workspace.
+    When there's a (large) pool of persistent agent nodes available to run a (large) number of builds,
+    eventually every agent node ends up with a copy of every builds' workspace.
     This is a waste of hardware resources as Jenkins will only look at the workspace on the most
-    recently used slave node.
+    recently used agent node.
     <br>
-    This functionality triggers a clean up of the workspace on all slave nodes
-    that are not currently being used so that, on average, the pool of slaves will only
+    This functionality triggers a clean up of the workspace on all agent nodes
+    that are not currently being used so that, on average, the pool of agents will only
     contain one workspace for each job.
 </div>


### PR DESCRIPTION
Part of IBM's #words-matter drive.
https://www.ibm.com/blogs/think/2020/08/words-matter-driving-thoughtful-change-toward-inclusive-language-in-technology/

Modified help.html file in wsclean-plugin/src/main/resources/de/jamba/hudson/plugin/wsclean/PrePostClean directory and modified "slave" to "agent".