### PR TITLE
Update terminology of 'slave' to 'agent'

### DIFF
--- a/src/main/java/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty.java
+++ b/src/main/java/de/jamba/hudson/plugin/wsclean/DisablePrePostCleanNodeProperty.java
@@ -8,7 +8,7 @@ import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 
 /**
- * Jenkins slave {@link NodeProperty} that, when set, causes
+ * Jenkins agent {@link NodeProperty} that, when set, causes
  * {@link PrePostClean} to skip the {@link Node}.
  */
 public class DisablePrePostCleanNodeProperty extends NodeProperty<Node> {

--- a/src/test/java/de/jamba/hudson/plugin/wsclean/PrePostCleanTest.java
+++ b/src/test/java/de/jamba/hudson/plugin/wsclean/PrePostCleanTest.java
@@ -265,7 +265,7 @@ public class PrePostCleanTest {
                 false, true);
         final AbstractBuild mockBuild10 = mockBuild("mockBuild10-concurrentWithUs-runningOnNode2", mockNode2, normalWs,
                 false, true);
-        final AbstractBuild mockBuild11 = mockBuild("mockBuild11-allocatedToSlaveButNotStartedYet", mockNode2, weirdWs,
+        final AbstractBuild mockBuild11 = mockBuild("mockBuild11-allocatedToAgentButNotStartedYet", mockNode2, weirdWs,
                 true, false);
         final AbstractBuild mockBuild12 = mockBuild("mockBuild12-notStartedYet", null, normalWs, true, false);
         final List<AbstractBuild> listOfMockBuildHistory = ImmutableList.of(mockBuild12, mockBuild11, mockBuild10,


### PR DESCRIPTION
Part of IBM's #words-matter drive.
https://www.ibm.com/blogs/think/2020/08/words-matter-driving-thoughtful-change-toward-inclusive-language-in-technology/

'slave' is deprecated and 'agent' should be used instead.